### PR TITLE
[1.4] Fixed "how to override product value"

### DIFF
--- a/cookbook/catalog_structure/overriding_the_mongodb_product_value.rst
+++ b/cookbook/catalog_structure/overriding_the_mongodb_product_value.rst
@@ -30,12 +30,12 @@ First, we need to extend and replace the native `PimCatalogBundle:ProductValue` 
     namespace Acme\Bundle\AppBundle\Model;
 
     use Acme\Bundle\AppBundle\Entity\Color;
-    use Pim\Bundle\CatalogBundle\Model\AbstractProductValue;
+    use Pim\Bundle\CatalogBundle\Model\ProductValue as PimProductValue;
 
     /**
      * Acme override of the product value to link a simple object
      */
-    class ProductValue extends AbstractProductValue
+    class ProductValue extends PimProductValue
     {
         /** @var Color */
         protected $color;
@@ -106,12 +106,12 @@ First, we need to extend and replace the native `PimCatalogBundle:ProductValue` 
 
     use Acme\Bundle\AppBundle\Entity\Color;
     use Doctrine\Common\Collections\ArrayCollection;
-    use Pim\Bundle\CatalogBundle\Model\AbstractProductValue;
+    use Pim\Bundle\CatalogBundle\Model\ProductValue as PimProductValue;
 
     /**
      * Acme override of the product value to link a multiple object
      */
-    class ProductValue extends AbstractProductValue
+    class ProductValue extends PimProductValue
     {
         /** @var ArrayCollection */
         protected $colors;

--- a/cookbook/catalog_structure/overriding_the_orm_product_value.rst
+++ b/cookbook/catalog_structure/overriding_the_orm_product_value.rst
@@ -30,12 +30,12 @@ First, we need to extend and replace the native `PimCatalogBundle:ProductValue` 
     namespace Acme\Bundle\AppBundle\Model;
 
     use Acme\Bundle\AppBundle\Entity\Color;
-    use Pim\Bundle\CatalogBundle\Model\AbstractProductValue;
+    use Pim\Bundle\CatalogBundle\Model\ProductValue as PimProductValue;
 
     /**
      * Acme override of the product value to link a simple object
      */
-    class ProductValue extends AbstractProductValue
+    class ProductValue extends PimProductValue
     {
         /** @var Color */
         protected $color;
@@ -122,12 +122,12 @@ First, we need to extend and replace the native `PimCatalogBundle:ProductValue` 
 
     use Acme\Bundle\AppBundle\Entity\Color;
     use Doctrine\Common\Collections\ArrayCollection;
-    use Pim\Bundle\CatalogBundle\Model\AbstractProductValue;
+    use Pim\Bundle\CatalogBundle\Model\ProductValue as PimProductValue;
 
     /**
      * Acme override of the product value to link a multiple object
      */
-    class ProductValue extends AbstractProductValue
+    class ProductValue extends PimProductValue
     {
         /** @var ArrayCollection */
         protected $colors;

--- a/cookbook/catalog_structure/overriding_the_orm_product_value.rst
+++ b/cookbook/catalog_structure/overriding_the_orm_product_value.rst
@@ -27,7 +27,7 @@ First, we need to extend and replace the native `PimCatalogBundle:ProductValue` 
     <?php
     # /src/Acme/Bundle/AppBundle/Entity/ProductValue.php
 
-    namespace Acme\Bundle\AppBundle\Model;
+    namespace Acme\Bundle\AppBundle\Entity;
 
     use Acme\Bundle\AppBundle\Entity\Color;
     use Pim\Bundle\CatalogBundle\Model\ProductValue as PimProductValue;
@@ -64,9 +64,9 @@ First, we need to extend and replace the native `PimCatalogBundle:ProductValue` 
 Overriding the mapping
 **********************
 
-Create the mapping file `Resources/config/model/doctrine/ProductValue.orm.yml` into your your bundle.
+Create the mapping file `Resources/config/doctrine/ProductValue.orm.yml` into your your bundle.
 
-First, copy the table name, the tracking policy and the indexes of the file `src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/ProductValue.orm.yml`.
+First, copy the table name, the tracking policy and the indexes of the file `src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/ProductValue.orm.yml`.
 
 .. code-block:: yaml
 
@@ -118,7 +118,7 @@ First, we need to extend and replace the native `PimCatalogBundle:ProductValue` 
     <?php
     # /src/Acme/Bundle/AppBundle/Entity/ProductValue.php
 
-    namespace Acme\Bundle\AppBundle\Model;
+    namespace Acme\Bundle\AppBundle\Entity;
 
     use Acme\Bundle\AppBundle\Entity\Color;
     use Doctrine\Common\Collections\ArrayCollection;


### PR DESCRIPTION
Both with MySQL and MongoDB

The existing code wasn't compliant with AcmeBundle code.

master version by @mathielen : https://github.com/akeneo/pim-docs/pull/192