### PR TITLE
Fix file path on cookbook 'add property to category'

### DIFF
--- a/cookbook/category/add-properties-to-category.rst
+++ b/cookbook/category/add-properties-to-category.rst
@@ -72,9 +72,16 @@ Then, you have to override the service definition of your form:
     :lines: 1-2
     :linenos:
 
-.. note::
+Then, add this new file to your dependency injection extension:
 
-    Don't forget to add this new file to your dependency injection extension
+.. code-block:: php
+
+    # /src/Acme/Bundle/EnrichBundle/DependencyInjection/AcmeAppExtension.php
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        /** ... **/
+        $loader->load('form_types.yml');
+    }
 
 Then, don't forget to add your new field to the twig template:
 
@@ -85,7 +92,7 @@ Then, don't forget to add your new field to the twig template:
 
 For the form validation you will have to add a new validation file:
 
-.. literalinclude:: ../../src/Acme/Bundle/AppBundle/Resources/config/validation.yml
+.. literalinclude:: ../../src/Acme/Bundle/CatalogBundle/Resources/config/validation/category.yml
     :language: yaml
-    :prepend: # /src/Acme/Bundle/AppBundle/Resources/config/validation.yml
+    :prepend: # /src/Acme/Bundle/CatalogBundle/Resources/config/validation/category.yml
     :linenos:

--- a/src/Acme/Bundle/CatalogBundle/Resources/config/validation/category.yml
+++ b/src/Acme/Bundle/CatalogBundle/Resources/config/validation/category.yml
@@ -1,4 +1,4 @@
-Acme\CatalogBundle\Entity\MyCategory:
+Acme\CatalogBundle\Entity\Category:
     properties:
         description:
             - NotBlank: ~


### PR DESCRIPTION
Fix the empty block at the end of this doc:
http://docs.akeneo.com/latest/cookbook/category/add-properties-to-category.html#define-the-category-form, and improve a little bit the doc.