### PR TITLE
Fix typo in datagrid.yml

### DIFF
--- a/src/Acme/Bundle/EnrichBundle/Resources/config/datagrid.yml
+++ b/src/Acme/Bundle/EnrichBundle/Resources/config/datagrid.yml
@@ -32,7 +32,7 @@ datagrid:
                 updated:
                     type:             date
                     label:            Updated
-                    data_name:        o.udapted
+                    data_name:        o.updated
                     filter_by_having: true
         sorters:
             columns:
@@ -43,6 +43,6 @@ datagrid:
                 created:
                     data_name: o.created
                 updated:
-                    data_name: o.udapted
+                    data_name: o.updated
             default:
                 code: '%oro_datagrid.extension.orm_sorter.class%::DIRECTION_ASC'


### PR DESCRIPTION
There's a typo in both datagrid.color.filters.updated.data_name and datagrid.color.sorters.updated.data_name