### PR TITLE
[TR] PIM-5612: Add Excel connector supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Add all Acme bundles in `app/AppKernel.php` file.
 
 ## Contribution
 
-Don't hesitate to propose cookbook entries via https://github.com/akeneo/pim-docs/issues
+Don't hesitate to suggest cookbook ideas via https://github.com/akeneo/pim-docs/issues

--- a/reference/import_export/connectors.rst
+++ b/reference/import_export/connectors.rst
@@ -1,0 +1,29 @@
+Akeneo Native Connector
+=======================
+
+CSV Format
+----------
+
+Akeneo Native Connector supports reading and writing CSV files.
+
+XLSX Format
+-----------
+
+Akeneo Native Connector supports reading and writing XLSX files. The connector uses an open source library called Spout (https://github.com/box/spout) to read and create XLSX files.
+
+The connector supports the following Excel versions:
+
+- Windows Excel 2016
+- Windows Excel 2013
+- Windows Excel 2010
+- Windows Excel 2007
+- Excel 16 (Office 2016 for OS X)
+- Excel 14 (Office 2011 for OS X)
+
+Customizing connectors
+----------------------
+
+It is possible to customize this connector to import and export numerous PIM related objects:
+
+- Check how to import PIM objects using this connector (cf :doc:`reference/import_export/simple-import.rst`)
+- In order to understand how the connector is working for products, please refer to chapters about product import (cf :doc:`/reference/import_export/product-export`) and product export (cf :doc:`/reference/import_export/product-export`)

--- a/reference/import_export/index.rst
+++ b/reference/import_export/index.rst
@@ -22,3 +22,4 @@ This chapter describes the architecture and behaviour of imports and exports in 
     main-concepts
     product-import
     product-export
+    connectors


### PR DESCRIPTION
Adds a connector section into the import/export chapter related to the Microsoft Office supported versions for xlsx files.