### PR TITLE
Remove dead links

### DIFF
--- a/developer_guide/migration/index.rst
+++ b/developer_guide/migration/index.rst
@@ -87,10 +87,14 @@ Here are the migration guides:
 * `From v1.4 to v1.5`_
 * `From v1.3 to v1.4`_
 * `From v1.2 to v1.3`_
+* `From v1.1 to v1.2`_
+* `From v1.0 to v1.1`_
 
 .. _From v1.4 to v1.5: https://github.com/akeneo/pim-community-standard/blob/1.5/UPGRADE-1.5.md
 .. _From v1.3 to v1.4: https://github.com/akeneo/pim-community-standard/blob/1.4/UPGRADE-1.4.md
 .. _From v1.2 to v1.3: https://github.com/akeneo/pim-community-standard/blob/1.3/UPGRADE-1.3.md
+.. _From v1.1 to v1.2: https://github.com/akeneo/pim-community-standard/blob/master/UPGRADE-1.1.md
+.. _From v1.0 to v1.1: https://github.com/akeneo/pim-community-standard/blob/master/UPGRADE-1.2.md
 
 **Enterprise Edition**
 

--- a/developer_guide/migration/index.rst
+++ b/developer_guide/migration/index.rst
@@ -87,14 +87,10 @@ Here are the migration guides:
 * `From v1.4 to v1.5`_
 * `From v1.3 to v1.4`_
 * `From v1.2 to v1.3`_
-* `From v1.1 to v1.2`_
-* `From v1.0 to v1.1`_
 
 .. _From v1.4 to v1.5: https://github.com/akeneo/pim-community-standard/blob/1.5/UPGRADE-1.5.md
 .. _From v1.3 to v1.4: https://github.com/akeneo/pim-community-standard/blob/1.4/UPGRADE-1.4.md
 .. _From v1.2 to v1.3: https://github.com/akeneo/pim-community-standard/blob/1.3/UPGRADE-1.3.md
-.. _From v1.1 to v1.2: https://github.com/akeneo/pim-community-standard/blob/1.2/UPGRADE-1.2.md
-.. _From v1.0 to v1.1: https://github.com/akeneo/pim-community-standard/blob/1.1/UPGRADE-1.1.md
 
 **Enterprise Edition**
 


### PR DESCRIPTION
These two migration links are dead. I don't think anyone will need the migration notes from that old versions, so I've just removed the lines.