### PR TITLE
Fix infos for asset transformation

### DIFF
--- a/cookbook/product_asset/add_new_transformation.rst
+++ b/cookbook/product_asset/add_new_transformation.rst
@@ -217,19 +217,21 @@ A translation key is automatically created with the ``Watermark->getName()``. Yo
 Add a Channel Configuration to Use the New Transformation
 ---------------------------------------------------------
 
-Adding a channel configuration for Reference transformation is a simple YML import :
+Adding a channel configuration for Reference transformation is a simple YML import:
 
-.. code-block:: csv
+.. code-block:: yaml
 
-    channel;configuration
-    mobile;{"watermark":{"size":"15", "watermark":"Copyright Akeneo"}}
+    asset_channel_configurations:
+        mobile:
+             configuration:
+                 watermark:
+                    size: 15
+                    watermark: "Copyright Akeneo"
 
-.. note::
-    Configuration is a json format. All these options are required but as we pushed a default value we can put nothing.
 
-Once you created YML file you can go to Akeneo PIM and then start importing with asset channel configuration import in csv profile.
-Be careful, if you import only the previous file, all your previous configurations will be removed. You need to add your own configuration in the file to keep it.
+Once you created YML file you can go to Akeneo PIM and then start importing with the asset channel configuration import in yml profile.
+Be careful, if you import only the new channel configuration file, all your previous configurations will be removed. You need to add your old configuration(s) in the file to keep it.
 
-Now try to create an asset and generate variations for your channel. Download the generated file and discover your watermark :
+Now try to create an asset and generate variations for your channel. Download the generated file and discover your watermark:
 
 .. image:: ./logo_watermark.png


### PR DESCRIPTION
we mention a csv file whereas it's a yml:
- remove csv mentions and csv example
- add a yml example