### PR TITLE
Change media rule structure according to the standard format

### DIFF
--- a/cookbook/rule/general_information_on_rule_format.rst
+++ b/cookbook/rule/general_information_on_rule_format.rst
@@ -697,11 +697,9 @@ _______________
 |              |                                   |
 |              |   field: small_image              |
 |              |   operator: CONTAIN               |
-|              |   value:                          |
-|              |    - filePath: ../../../          |
+|              |   value: ../../../                |
 |              |    src/PimEnterprise/Bundle/      |
 |              |    InstallerBundle/Resources/     |
 |              |    fixtures/icecat_demo/images/   |
 |              |    AKNTS_PB.jpg                   |
-|              |    - originalFilename: akeneo.jpg |
 +--------------+-----------------------------------+


### PR DESCRIPTION
Standard format has changed for media attributes. 

The notion of originalFilename does not exist anymore. The value is directly the file path.
Filename is determined according to the file path.