### PR TITLE
Fix a typo in Category override cookbook

### DIFF
--- a/cookbook/category/add-properties-to-category.rst
+++ b/cookbook/category/add-properties-to-category.rst
@@ -70,6 +70,13 @@ You need to update your category entity parameter used in ``entities.yml`` file:
    You don't have to add a lot of code to the Doctrine configuration to resolve target entities.
    We already have a resolver which injects the new category class name.
 
+Now, you can run the following commands to update your database:
+
+.. code-block:: bash
+
+    php app/console doctrine:schema:update --dump-sql
+    php app/console doctrine:schema:update --force
+
 Define the Category Form
 ************************
 
@@ -209,6 +216,13 @@ You need to update your category entity parameter used in ``entities.yml`` file:
 .. note::
    You don't have to add a lot of code to the Doctrine configuration to resolve target entities.
    We already have a resolver which injects the new category class name.
+
+Now, you can run the following commands to update your database:
+
+.. code-block:: bash
+
+    php app/console doctrine:schema:update --dump-sql
+    php app/console doctrine:schema:update --force
 
 Define the Category Form
 ************************

--- a/src/Acme/Bundle/EnrichBundle/Form/Type/TranslatableCategoryType.php
+++ b/src/Acme/Bundle/EnrichBundle/Form/Type/TranslatableCategoryType.php
@@ -17,13 +17,13 @@ class CategoryType extends BaseCategoryType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         parent::buildForm($builder, $options);
-        
+
         $builder->add(
             'description',
             'pim_translatable_field',
             [
                 'field'             => 'description',
-                'translation_class' => $this->translationdataClass,
+                'translation_class' => $this->translationDataClass,
                 'entity_class'      => $this->dataClass,
                 'property_path'     => 'translations',
                 'widget'            => 'textarea',


### PR DESCRIPTION
A typo has been fixed in the class `CategoryType` in 1.6, but not in the cookbook.