### PR TITLE
Ease the construction of Job and Validator step

### DIFF
--- a/reference/import_export/product-import.rst
+++ b/reference/import_export/product-import.rst
@@ -11,7 +11,7 @@ You can now natively import data into CSV and XLSX format.
 Definition of the Job
 ---------------------
 
-Take a look to this configuration based on ConnectorBundle (``src/Pim/Bundle/ConnectorBundle/Resources/config/jobs.yml``).
+Take a look at this configuration based on ConnectorBundle (``src/Pim/Bundle/ConnectorBundle/Resources/config/jobs.yml``).
 
 .. code-block:: yaml
 

--- a/reference/import_export/product-import.rst
+++ b/reference/import_export/product-import.rst
@@ -11,23 +11,19 @@ You can now natively import data into CSV and XLSX format.
 Definition of the Job
 ---------------------
 
-The product import is defined in ``src/Pim/Bundle/ConnectorBundle/Resources/config/jobs.yml``.
+Take a look to this configuration based on ConnectorBundle (``src/Pim/Bundle/ConnectorBundle/Resources/config/jobs.yml``).
 
 .. code-block:: yaml
 
     parameters:
-        pim_connector.connector_name.csv: 'Akeneo CSV Connector'
-        pim_connector.connector_name.xlsx: 'Akeneo XLSX Connector'
-        pim_connector.job_name.csv_product_import: 'csv_product_import'
         pim_connector.job.simple_job.class: Akeneo\Component\Batch\Job\Job
-        pim_connector.job.import_type: import
 
     services:
         ## CSV product import
         pim_connector.job.csv_product_import:
             class: '%pim_connector.job.simple_job.class%'
             arguments:
-                - '%pim_connector.job_name.csv_product_import%'
+                - 'csv_product_import'
                 - '@event_dispatcher'
                 - '@akeneo_batch.job_repository'
                 -
@@ -35,13 +31,13 @@ The product import is defined in ``src/Pim/Bundle/ConnectorBundle/Resources/conf
                     - '@pim_connector.step.csv_product.import'
                     - '@pim_connector.step.csv_product.import_associations'
             tags:
-                - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.csv%', type: '%pim_connector.job.import_type%' }
+                - { name: akeneo_batch.job, connector: 'Akeneo CSV Connector', type: 'import' }
 
         ## XLSX product import
         pim_connector.job.xlsx_product_import:
             class: '%pim_connector.job.simple_job.class%'
             arguments:
-                - '%pim_connector.job_name.xlsx_product_import%'
+                - 'xlsx_product_import'
                 - '@event_dispatcher'
                 - '@akeneo_batch.job_repository'
                 -
@@ -49,7 +45,7 @@ The product import is defined in ``src/Pim/Bundle/ConnectorBundle/Resources/conf
                     - '@pim_connector.step.xlsx_product.import'
                     - '@pim_connector.step.xlsx_product.import_associations'
             tags:
-                - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.xlsx%', type: '%pim_connector.job.import_type%' }
+                - { name: akeneo_batch.job, connector: 'Akeneo XLSX Connector', type: 'import' }
 
 With the ``type`` parameter, we can see that this job is an import.
 
@@ -75,11 +71,6 @@ This step is defined in ``src/Pim/Bundle/ConnectorBundle/Resources/config/steps.
                 - '@event_dispatcher'
                 - '@akeneo_batch.job_repository'
                 - '@pim_connector.validator.item.charset_validator'
-
-.. code-block:: yaml
-
-    parameters:
-        pim_connector.step.validator.class: Pim\Component\Connector\Step\ValidatorStep
 
 We can also see that we inject a service ``pim_connector.validator.item.charset_validator`` in this step.
 

--- a/reference/import_export/product-import.rst
+++ b/reference/import_export/product-import.rst
@@ -56,7 +56,7 @@ The purpose of this step is to validate that the input file has the expected enc
 
 This step is a custom step, not a default ``ItemStep``.
 
-This step is defined in ``src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml`
+This step is defined in ``src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml``
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Also, fixed missing parameter `pim_connector.job_name.xlsx_product_import`

I can understand that Akeneo's code needs to be very decoupled with parameters, but from a beginner point of view, this made the example hard to understand.

Also removed duplicated block.