### PR TITLE
Add links to standards and conventions

### DIFF
--- a/reference/best_practices/index.rst
+++ b/reference/best_practices/index.rst
@@ -11,3 +11,6 @@ Best Practices
 
     project
     reusable_bundle
+    ./core/behat
+    ./core/conventions
+    ./core/standards


### PR DESCRIPTION
Links are not visible right now, except in the Cookbook about how to do Behat tests.