### PR TITLE
Added a note on X-Debug-Token-Link

### DIFF
--- a/troubleshooting/bug_qualification/index.rst
+++ b/troubleshooting/bug_qualification/index.rst
@@ -39,6 +39,10 @@ Backend bugs are issues which occur on the server side (PHP/Symfony code, databa
 * Analyze the error messages provided in the Symfony's log files ``/path/to/your/pim/app/logs/prod.log`` or ``/path/to/your/pim/app/logs/dev.log``
 * Take a look at the PHP error log file.
 
+.. note::
+
+    If the web debug toolbar is not displayed in ``dev`` environment, you can retrieve the link in ``X-Debug-Token-Link`` header of request.
+
 Tasks bugs
 ----------
 


### PR DESCRIPTION
Most of the time, if you have an error in Back Office or using the REST Api, you don't have direct access to the Web debug toolbar and the profiler.

It's sad but not lost! The X-Debug-Token-Link HTTP HEADER key provide a relative link to the profiler :)