### PR TITLE
Fixed misuse of "*" for list item

### DIFF
--- a/cookbook/setup_data/customize_dataset.rst
+++ b/cookbook/setup_data/customize_dataset.rst
@@ -79,13 +79,13 @@ Mandatory Data
 
 Be sure you have included mandatory data in your custom installation fixtures. These are:
 
-* user group ``all`` named ``All`` regardless of the translation in your ``user_groups.yml``;
-* attribute group ``other`` in your ``attribute_groups.yml``.
+ - user group ``all`` named ``All`` regardless of the translation in your ``user_groups.yml``;
+ - attribute group ``other`` in your ``attribute_groups.yml``.
 
 You should also make sure that:
-* your product attributes have only one attribute of type ``pim_catalog_identifier`` (SKU by default)
-* you have at least one ``channel`` in your ``channels.yml``
-* you have at least one ``category tree`` (default: master) in your ``categories.csv``
+ - your product attributes have only one attribute of type ``pim_catalog_identifier`` (SKU by default);
+ - you have at least one ``channel`` in your ``channels.yml``;
+ - you have at least one ``category tree`` (default: master) in your ``categories.csv``.
 
 .. note::
 


### PR DESCRIPTION
Hello,

lists were not displayed correctly, in ReSt we use "-" instead of "*" in markdown.

Mickaël