### PR TITLE
Introduced Youtube videos support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
   directories: [$HOME/.cache/pip]
 
 # command to install dependencies
-install: "pip install sphinx~=1.5.3 git+https://github.com/fabpot/sphinx-php.git"
+install: "pip install sphinx~=1.5.3 git+https://github.com/fabpot/sphinx-php.git git+https://github.com/mickaelandrieu/sphinxcontrib.youtube.git"
 
 # command to run tests
 script: sphinx-build -nW -b html -d _build/doctrees . _build/html

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Install [Sphinx](http://sphinx-doc.org/).
 ```bash
     $ sudo pip install sphinx~=1.5.3
     $ sudo pip install git+https://github.com/fabpot/sphinx-php.git
+    $ sudo pip install git+https://github.com/mickaelandrieu/sphinxcontrib.youtube.git
 ```
 
 ### Mac OS
@@ -20,6 +21,7 @@ Install [Sphinx](http://sphinx-doc.org/).
     $ brew install python
     $ pip install sphinx
     $ pip install git+https://github.com/fabpot/sphinx-php.git
+    $ pip install git+https://github.com/mickaelandrieu/sphinxcontrib.youtube.git
 ```
 
 Download composer `curl -s https://getcomposer.org/installer | php` and run `php composer.phar install`.

--- a/conf.py
+++ b/conf.py
@@ -29,7 +29,7 @@ from pygments.lexers.web import PhpLexer
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sensio.sphinx.refinclude', 'sensio.sphinx.configurationblock', 'sensio.sphinx.phpcode' , 'sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.ifconfig', 'sensio.sphinx.configurationblock']
+extensions = ['sensio.sphinx.refinclude', 'sensio.sphinx.configurationblock', 'sensio.sphinx.phpcode' , 'sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.ifconfig', 'sensio.sphinx.configurationblock', 'sphinxcontrib.youtube']
 lexers['php'] = PhpLexer(startinline=True)
 lexers['php-annotations'] = PhpLexer(startinline=True)
 


### PR DESCRIPTION
Hello,

we have very good resources to learn Akeneo on youtube, I think it could be nice to teach every technical part with "his" functional importance ("Why is this important for Julia?").

To include a Youtube video, it's really simple:

```rst
.. youtube:: https://www.youtube.com/watch?v=fmHAz9pSS38
// or
.. youtube:: fmHAz9pSS38
```

![youtube_support](https://cloud.githubusercontent.com/assets/1247388/23945653/98fcb05a-0977-11e7-9a84-07d2a5dd3d0f.PNG)
