### PR TITLE
Update installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Clone this repository.
 
 Install [Sphinx](http://sphinx-doc.org/).
 ```bash
+    $ sudo pip install --upgrade pip
     $ sudo pip install sphinx~=1.5.3
     $ sudo pip install git+https://github.com/fabpot/sphinx-php.git
     $ sudo pip install git+https://github.com/mickaelandrieu/sphinxcontrib.youtube.git
@@ -23,6 +24,9 @@ Install [Sphinx](http://sphinx-doc.org/).
     $ pip install git+https://github.com/fabpot/sphinx-php.git
     $ pip install git+https://github.com/mickaelandrieu/sphinxcontrib.youtube.git
 ```
+
+> If you encounter the following error ``ValueError: ('Expected version spec in', 'sphinx~=1.5.3', 'at', '~=1.5.3')``
+  Use ``pip install --upgrade pip`` before install sphinx
 
 Download composer `curl -s https://getcomposer.org/installer | php` and run `php composer.phar install`.
 


### PR DESCRIPTION
Some minors improvements to the documentation, `pip`(ou) needs to be up to date in order to install sphinx 1.5.3

ping @phaseinducer 