### PR TITLE
Display docs version in a better place

### DIFF
--- a/_themes/akeneo_rtd/layout.html
+++ b/_themes/akeneo_rtd/layout.html
@@ -113,21 +113,10 @@
             <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" />
           {% endif %}
           </a>
-
-          {% if theme_display_version %}
-            {%- set nav_version = version %}
-            {% if READTHEDOCS and current_version %}
-              {%- set nav_version = current_version %}
-            {% endif %}
-            {% if nav_version %}
-              <div class="version">
-                {{ nav_version }}
-              </div>
-            {% endif %}
-          {% endif %}
-
           {% endblock %}
         </div>
+
+        {% include "versions.html" %}
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
           {% block menu %}
@@ -171,7 +160,6 @@
     </section>
 
   </div>
-  {% include "versions.html" %}
 
   {% if not embedded %}
 

--- a/_themes/akeneo_rtd/static/css/akeneo.css
+++ b/_themes/akeneo_rtd/static/css/akeneo.css
@@ -24,13 +24,14 @@ a {
 
 /* Left column */
 .wy-side-nav-search>a, .wy-side-nav-search .wy-dropdown>a {
-    margin-bottom: 0;
+    margin-bottom: 0 !important;
 }
 .wy-side-nav-search>div.version {
     display:none;
 }
 .wy-side-nav-search {
     background-color: #ffffff;
+    margin-bottom: 0 !important;
 }
 .wy-nav-side {
     background: #11324D; /* Akeneo dark blue */
@@ -39,11 +40,12 @@ a {
     position: static;
     bottom: initial;
     border-top:solid 0px #0b2132; /* Akeneo dark blue darken */
-    border-bottom:solid 6px #edf0f2; /* Grey background */
+    border-bottom:solid 1px #edf0f2; /* Grey background */
 }
 .rst-versions .rst-current-version {
     background-color: #11324D; /* Akeneo dark blue */
     color: #fff;
+    padding-top: 13px !important;
 }
 .wy-menu-vertical ul {
     margin-bottom: 18px;
@@ -175,4 +177,10 @@ footer .platformsh-logo {
     display: inline-block;
     line-height: 25px;
     vertical-align: -5px;
+}
+
+/* align elements */
+span.fa.fa-book {
+    float: none;
+    line-height: normal;
 }

--- a/_themes/akeneo_rtd/static/css/akeneo.css
+++ b/_themes/akeneo_rtd/static/css/akeneo.css
@@ -35,12 +35,15 @@ a {
 .wy-nav-side {
     background: #11324D; /* Akeneo dark blue */
 }
-.rst-versions {
-    border-top: solid 10px #11324D; /* Akeneo dark blue */
+.rst-versions.custom-version {
+    position: static;
+    bottom: initial;
+    border-top:solid 0px #0b2132; /* Akeneo dark blue darken */
+    border-bottom:solid 6px #edf0f2; /* Grey background */
 }
 .rst-versions .rst-current-version {
-    background-color: #0b2132; /* Akeneo dark blue darken */
-    color: #67B373; /* Akeneo fern green */
+    background-color: #11324D; /* Akeneo dark blue */
+    color: #fff;
 }
 .wy-menu-vertical ul {
     margin-bottom: 18px;

--- a/_themes/akeneo_rtd/versions.html
+++ b/_themes/akeneo_rtd/versions.html
@@ -1,7 +1,7 @@
-<div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+<div class="rst-versions custom-version" data-toggle="rst-versions" role="note" aria-label="versions">
   <span class="rst-current-version" data-toggle="rst-current-version">
     <span class="fa fa-book"> {{ project }}</span>
-    v: {{ version }}
+    version: <b>{{ version }}</b> 
     <span class="fa fa-caret-down"></span>
   </span>
   <div class="rst-other-versions">

--- a/_themes/sphinx_rtd_theme/layout.html
+++ b/_themes/sphinx_rtd_theme/layout.html
@@ -120,6 +120,7 @@
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
+          {% include "versions.html" %}
           {% block menu %}
             {% set toctree = toctree(maxdepth=4, collapse=theme_collapse_navigation, includehidden=True) %}
             {% if toctree %}


### PR DESCRIPTION
A minor but useful improvement: regarding Google analytics stats, EVERY people is looking at "latest" documentation and not at the documentation for his own version.

This may lead to many errors, and probably due to the actual version position, which is not really "visible".

<details>
<summary>Before</summary>

![old_menu](https://cloud.githubusercontent.com/assets/1247388/24255140/f16bbbbe-0fe4-11e7-9edc-061aa83fdc2b.PNG)

![old_menu_2](https://cloud.githubusercontent.com/assets/1247388/24255141/f1869e7a-0fe4-11e7-9b1e-46194d245c53.PNG)
</details>


<details>
<summary>After</summary>

![new](https://cloud.githubusercontent.com/assets/1247388/24342970/55df3f08-12c4-11e7-8f1f-655b80a27234.PNG)

![new2](https://cloud.githubusercontent.com/assets/1247388/24342993/6a74b182-12c4-11e7-8da5-4d68ae942955.PNG)
</details>
