### PR TITLE
Introduced PIM_VERSIONS env var to set the displayable versions

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -59,9 +59,11 @@ copyright = u'2015, Akeneo SAS'
 #
 # The short X.Y version.
 version = os.getenv('PIM_VERSION', '1.0')
-html_context = {
+
 # Warning: These versions will be deleted on documentation deploy.
-    'versions': ['master', '1.5', '1.4', '1.3'],
+versions = os.getenv('PIM_VERSIONS', 'master 1.0')
+html_context = {
+    'versions': versions.split(' '),
     'css_files': [
         'https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css',
         '_static/css/akeneo.css',


### PR DESCRIPTION
Hello,

this is part of https://github.com/akeneo/pim-docs/issues/568.

The global idea is to not have to sed a configuration file in order to publish our documentation.

Using `PIM_VERSIONS` environment variable, we can change the versions displayed in selector of versions for each Sphinx build.

> How to use/test it?

```bash
PIM_VERSIONS=master foo bar baz 1.0
sphinx-build -b html . ./build
```

**This doesn't means you can publish a multi version docs at this moment, this is only about the versions displayed by the selector of versions.**

This contribution needs to be applied from 1.0 to master branches.
