### PR TITLE
Standalone styleguide installation using composer

### DIFF
--- a/styleguide/composer.json
+++ b/styleguide/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "akeneo/styleguide",
+    "description": "Styleguide of the Akeneo PIM",
+    "authors": [
+        {
+            "name": "Akeneo",
+            "homepage": "http://www.akeneo.com"
+        }
+    ],
+    "require": {
+        "twig/twig": "~2.3",
+        "symfony/yaml": "~2.8"
+    }
+}

--- a/styleguide/index.php
+++ b/styleguide/index.php
@@ -1,5 +1,7 @@
 <?php
-require_once("../vendor/autoload.php");
+require_once("./vendor/autoload.php");
+
+use Symfony\Component\Yaml\Yaml;
 
 $loader = new \Twig_Loader_Filesystem(__DIR__.'/templates');
 $twig = new \Twig_Environment($loader);
@@ -7,7 +9,7 @@ $twig = new \Twig_Environment($loader);
 $renderCodeFunction = new Twig_SimpleFunction('render_code', function ($template, $code, $args = []) {
     global $twig;
 
-    $result = '<div class="reset-bem' . ($args['dark'] ? ' dark' : '') . '">';
+    $result = '<div class="reset-bem' . (array_key_exists('dark', $args) ? ' dark' : '') . '">';
     $htmlCode = $twig->render($template, $args);
     $result .= $htmlCode;
     $result .= '</div>';
@@ -17,7 +19,7 @@ $renderCodeFunction = new Twig_SimpleFunction('render_code', function ($template
 });
 $twig->addFunction($renderCodeFunction);
 
-$yaml = \Symfony\Component\Yaml\Yaml::parse(file_get_contents('config.yml'));
+$yaml = Yaml::parse(file_get_contents('config.yml'));
 
 ?><!DOCTYPE html>
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
@@ -25,12 +27,12 @@ $yaml = \Symfony\Component\Yaml\Yaml::parse(file_get_contents('config.yml'));
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Akeneo PIM Documentation &mdash; Akeneo PIM documentation</title>
+    <title>Akeneo PIM Documentation &mdash; Akeneo PIM styleguide</title>
     <link rel="shortcut icon" href="../_static/favicon.ico"/>
     <link rel="stylesheet" href="../_static/css/theme.css" type="text/css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" type="text/css" />
     <link rel="stylesheet" href="../_static/css/akeneo.css" type="text/css" />
-    <link rel="top" title="Akeneo PIM documentation" href="#"/>
+    <link rel="top" title="Akeneo PIM styleguide" href="#"/>
     <link rel="next" title="Installation" href="developer_guide/installation/index.html"/>
     <script src="../_static/js/modernizr.min.js"></script>
 


### PR DESCRIPTION
Hello,

this is part of https://github.com/akeneo/pim-docs/issues/568.

The global idea is to make the deployment faster by remove all validation from deploy to testing workflow instead (this means we will continue to install the PIM when validating a pull request).

Today, styleguide use the PIM dependencies, so we need to set the dependencies of styleguide in his own composer.json file.

> How to use/test it?

```bash
cd styleguide
composer install
php -S localhost:1234
```

You can see the website looks ugly (cause of css and js files that come from files that don't exists atm) but the HTML is correctly generated by Twig.

This contribution needs to be applied from 1.7 to master branches.