### PR TITLE
Added PIM app installation check on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,28 @@
-language: python
-python:
-  - "2.7"
+language: php
+php: 5.6
 
 sudo: false
+
 cache:
-  directories: [$HOME/.cache/pip]
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.composer/cache/files
+
+# disable xdebug
+before_install:
+  - phpenv config-rm xdebug.ini
+  - export PATH=$HOME/.local/bin:$PATH
+  - mysql -e 'CREATE DATABASE IF NOT EXISTS akeneo_pim;'
 
 # command to install dependencies
-install: "pip install sphinx~=1.5.3 git+https://github.com/fabpot/sphinx-php.git git+https://github.com/mickaelandrieu/sphinxcontrib.youtube.git"
+install:
+ - "pip install --user `whoami` sphinx~=1.5.3 git+https://github.com/fabpot/sphinx-php.git git+https://github.com/mickaelandrieu/sphinxcontrib.youtube.git"
 
 # command to run tests
-script: sphinx-build -nW -b html -d _build/doctrees . _build/html
+script:
+ - composer install --no-ansi --no-dev --no-progress
+ - sphinx-build -nWT -b dummy . _build/
 # Flags used here, not in `make html`:
 #  -n   Run in nit-picky mode. Currently, this generates warnings for all missing references.
 #  -W   Turn warnings into errors. This means that the build stops at the first warning and sphinx-build exits with exit status 1.
+#  -T   Displays the full stack trace if an unhandled exception occurs. 

--- a/app/config/parameters.yml
+++ b/app/config/parameters.yml
@@ -1,0 +1,9 @@
+parameters:
+    database_driver:   pdo_mysql
+    database_host:     127.0.0.1
+    database_port:     ~
+    database_name:     akeneo_pim
+    database_user:     root
+    database_password:
+    locale:            en
+    secret:            TravisConfigurationDontDeleteIt

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
             "ln -sf $(pwd)/vendor/akeneo/pim-community-dev/app/config/config.yml $(pwd)/app/config/",
             "ln -sf $(pwd)/vendor/akeneo/pim-community-dev/app/config/config_dev.yml $(pwd)/app/config/",
             "ln -sf $(pwd)/vendor/akeneo/pim-community-dev/app/config/security.yml $(pwd)/app/config/",
-            "ln -sf $(pwd)/vendor/akeneo/pim-community-dev/app/config/parameters.yml.dist $(pwd)/app/config/parameters.yml",
             "ln -sf $(pwd)/vendor/akeneo/pim-community-dev/app/config/pim_parameters.yml $(pwd)/app/config/",
             "php app/console asset:install || php app/console asset:install",
             "php app/console oro:assetic:dump"


### PR DESCRIPTION
Hello,

this is part of https://github.com/akeneo/pim-docs/issues/568.

The global idea is to make the deployment faster by remove all validation from deploy to testing workflow instead (this means we will continue to install the PIM when validating a pull request).

Today, everytime we deploy we check again the PIM application integrity embed in the docs, which was good when we didn't have travis. I'd like to let Travis handle this task too :)

> How to use/test it?

Nothing to do, only take a look at Travis build.

This contribution needs to be applied from 1.7 to master branches.