### PR TITLE
Fixes all 404 and weird 302 links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ install:
 # command to run tests
 script:
  - composer install --no-ansi --no-dev --no-progress
- - sphinx-build -nWT -b dummy . _build/
-# Flags used here, not in `make html`:
+ - sphinx-build -nWT -b linkcheck . _build/
+# Flags used here
 #  -n   Run in nit-picky mode. Currently, this generates warnings for all missing references.
 #  -W   Turn warnings into errors. This means that the build stops at the first warning and sphinx-build exits with exit status 1.
 #  -T   Displays the full stack trace if an unhandled exception occurs. 
+#  linkcheck builder checks for broken links.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please read and sign the following contributor agreement http://www.akeneo.com/contributor-license-agreement/
+Please read and sign the following contributor agreement https://www.akeneo.com/contributor-license-agreement/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ From the `./pim-docs` directory, run:
 
 The documentation will be generated inside `../pim-docs-build`.
 
+## Validate the documentation
+
+From the `./pim-docs` directory, run:
+
+``` bash
+    $ sphinx-build -nWT -b linkcheck . _build/
+```
+
 ## Make documentation code work with pim-community-dev or standard
 
 Install pim-community

--- a/app/console
+++ b/app/console
@@ -2,7 +2,7 @@
 <?php
 
 // if you don't want to setup permissions the proper way, just uncomment the following PHP line
-// read http://symfony.com/doc/current/book/installation.html#configuration-and-setup for more information
+// read https://symfony.com/doc/current/book/installation.html#configuration-and-setup for more information
 //umask(0000);
 
 set_time_limit(0);

--- a/conf.py
+++ b/conf.py
@@ -265,3 +265,6 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+# When using "linkckeck" builder, no checks on anchors.
+linkcheck_anchors = False

--- a/contributing/contribution_guide.rst
+++ b/contributing/contribution_guide.rst
@@ -10,7 +10,7 @@ If you don't know how to start, you can pick an issue here: https://github.com/a
 Step 0: Sign the Contributor Agreement
 --------------------------------------
 
-To be able to merge your contribution, we need you to read and sign the following contributor agreement http://www.akeneo.com/contributor-license-agreement/
+To be able to merge your contribution, we need you to read and sign the following contributor agreement https://www.akeneo.com/contributor-license-agreement/
 
 Step 1: Set up your Environment
 -------------------------------
@@ -122,8 +122,8 @@ branch (you can check the branch you are working on with ``git branch``).
 Work on your Patch
 ~~~~~~~~~~~~~~~~~~
 
-Before working on a contribution for an Akeneo repository, please read the following `code conventions`_
-and `coding standard`_ to make sure you respect all our standards.
+Before working on a contribution for an Akeneo repository, please read the following :doc:`/reference/best_practices/core/conventions`
+and :doc:`coding standards </reference/best_practices/core/standards>` to make sure you respect all our standards.
 
 When you work on a patch, please keep in mind:
 
@@ -136,7 +136,7 @@ When you work on a patch, please keep in mind:
 
 .. note::
 
-    We wrote a guide to `setup behat`_ in Akeneo PIM and you can check the `behat quick intro`_ on their documentation.
+    We wrote a guide to :doc:`setup behat </reference/best_practices/core/behat>` in Akeneo PIM and you can check the `behat quick intro`_ on their documentation.
 
     Here is the documentation to `begin with PHPSpec`_ and `Prophecy documentation`_.
 
@@ -169,7 +169,7 @@ It will help us to:
  - Revert a single commit if needed
  - Cherry pick a commit if needed
 
-Example of a well formed commit message (from github doc https://git-scm.com/book/ch5-2.html)
+Example of a well formed commit message (from `Git documentation <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>`_).
 
 .. note::
 
@@ -381,20 +381,17 @@ you to edit the commit message, which by default is a listing of the commit
 messages of all the commits. When you are finished, execute the push command.
 
 .. _`Akeneo PIM repository`:            https://github.com/akeneo/pim-community-dev
-.. _ProGit:                             http://git-scm.com/book
-.. _GitHub:                             https://github.com/signup/free
+.. _ProGit:                             https://git-scm.com/book/en/v2
+.. _GitHub:                             https://github.com/join
 .. _`GitHub's Documentation`:           https://help.github.com/articles/ignoring-files
 .. _`documentation repository`:         https://github.com/akeneo/pim-docs
-.. _`Sylius documentation`:             http://docs.sylius.org/en/latest/contributing/index.html
-.. _`code conventions`:                 http://docs.akeneo.com/latest/reference/best_practices/core/conventions.html
-.. _`coding standard`:                  http://docs.akeneo.com/latest/reference/best_practices/core/standards.html
-.. _`setup behat`:                      http://docs.akeneo.com/latest/reference/best_practices/core/behat.html
+.. _`Sylius documentation`:             http://docs.sylius.org/en/latest/                  
 .. _`behat quick intro`:                http://docs.behat.org/en/v2.5/quick_intro.html
-.. _`begin with PHPSpec`:               http://www.phpspec.net/en/latest/
+.. _`begin with PHPSpec`:               https://www.phpspec.net/en/latest/
 .. _`Prophecy documentation`:           https://github.com/phpspec/prophecy#prophecy
 .. _`Doctrine migration documentation`: http://docs.doctrine-project.org/projects/doctrine-migrations/en/latest/reference/introduction.html
 
 Step 4: Is my pull request merged?
 ----------------------------------
 
-Once your Pull Request is merged, don't hesitate to claim your badge "Core contributor" on badger at http://badger.akeneo.com/badge/41acec2c-649f-11e6-92dc-d60437e930cf
+Once your Pull Request is merged, don't hesitate to claim your badge "Core contributor" on `Badger platform <http://badger.akeneo.com/login/>`_.

--- a/contributing/create_connector.rst
+++ b/contributing/create_connector.rst
@@ -5,4 +5,4 @@ We're happy to connect the PIM to any third-party system!
 
 * Begin by checking on the forum that nobody is writing the same connector: https://www.akeneo.com/forums/forum/importexport-connectors/
 * Create your connector :doc:`/cookbook/import_export/create-connector`
-* Reference it on http://marketplace.akeneo.com/
+* Reference it on https://marketplace.akeneo.com/

--- a/contributing/documentation.rst
+++ b/contributing/documentation.rst
@@ -6,9 +6,7 @@ Enhance the Documentation
 How to contribute
 -----------------
 
-Want to help improve the `Documentation`_?
-
-.. _Documentation: http://docs.akeneo.com/latest/index.html
+Want to help improve the Documentation?
 
 The Akeneo PIM documentation uses `reStructuredText`_ as its markup language and
 `Sphinx`_ for building the output (HTML, PDF, ...).
@@ -27,7 +25,7 @@ To test the rendering of the documentation you can follow this `HowTo`_.
 
 .. _HowTo: https://github.com/akeneo/pim-docs/blob/master/README.md
 
-Once your Pull Request is merged, don't hesitate to claim your badge on badger at http://badger.akeneo.com/badge/0a25c62e-1bae-11e6-92dc-d60437e930cf !
+Once your Pull Request is merged, don't hesitate to claim your badge "Core contributor" on `Badger platform <http://badger.akeneo.com/login/>`_!
 
 reStructuredText
 ----------------
@@ -162,7 +160,7 @@ also specify alternative text for the link:
 
 .. code-block:: rst
 
-    :doc:`Le Lien </bundles/FooBundle/installation>`
+    :doc:`</bundles/FooBundle/installation>`
 
 You can also add links to the PHP documentation:
 
@@ -175,10 +173,10 @@ You can also add links to the PHP documentation:
     :phpfunction:`iterator_to_array`
 
 .. _reStructuredText:        http://docutils.sourceforge.net/rst.html
-.. _Sphinx:                  http://sphinx-doc.org/
+.. _Sphinx:                  http://www.sphinx-doc.org/en/stable/
 .. _documents:               https://github.com/akeneo/pim-docs
-.. _reStructuredText Primer: http://sphinx-doc.org/rest.html
-.. _markup:                  http://sphinx-doc.org/markup/
+.. _reStructuredText Primer: http://www.sphinx-doc.org/en/stable/rest.html
+.. _markup:                  http://www.sphinx-doc.org/en/stable/markup/
 .. _Pygments website:        http://pygments.org/languages/
 .. _source:                  https://github.com/fabpot/sphinx-php
-.. _Sphinx quick setup:      http://sphinx-doc.org/tutorial.html#setting-up-the-documentation-sources
+.. _Sphinx quick setup:      http://www.sphinx-doc.org/en/stable/tutorial.html#setting-up-the-documentation-sources

--- a/contributing/report_bug.rst.inc
+++ b/contributing/report_bug.rst.inc
@@ -11,9 +11,9 @@ Report a Bug
 
 **Community Edition**
 
-* Check if the issue is reproducible on http://demo.akeneo.com
-* Check if this issue is already known: https://github.com/akeneo/pim-community-dev/issues
-* Clone https://github.com/akeneo/pim-community-dev and checkout the branch of the version you want to test
+* Check if the issue is reproducible on `Demo website <http://demo.akeneo.com/user/login>`_
+* Check if this issue is `already known <https://github.com/akeneo/pim-community-dev/issues>`_
+* Clone `the development repository <https://github.com/akeneo/pim-community-dev>`_ and checkout the branch of the version you want to test
 * Reproduce the bug
 * Gather as much information as possible by following our :doc:`/troubleshooting/bug_qualification/index` guide
 * Create a new `GitHub <https://github.com/akeneo/pim-community-dev/>`_ issue which:
@@ -23,7 +23,7 @@ Report a Bug
   * Provides the PIM system information available under System > System information
   * Provides as much information as possible on your environment (OS, PHP version, browser)
 
-* Don't hesitate to claim your badge "`Bug Hunter <http://badger.akeneo.com/badge/57861115-69f6-11e6-92dc-d60437e930cf>`_" on `badger <http://badger.akeneo.com/>`_
+* Don't hesitate to claim your badge "Bug Hunter" on `badger <http://badger.akeneo.com/login>`_
 
 **Enterprise Edition**
 

--- a/contributing/translate.rst
+++ b/contributing/translate.rst
@@ -8,13 +8,13 @@ We use `Crowdin`_ to translate the PIM.
 How to translate
 ----------------
 
-Don't hesitate to create an account and begin to translate on: http://crowdin.net/project/akeneo
+Don't hesitate to create an account and begin to translate on: https://crowdin.net/project/akeneo
 
 If your language is not enabled, don't hesitate to ask, we'll enable it with pleasure.
 
 If you want to become a proofreader and be able to validate translations for a language, don't hesitate to ask.
 
-Don't hesitate to claim your badge "El Translator" on badger at http://badger.akeneo.com/badge/cce9c0ec-69f7-11e6-92dc-d60437e930cf
+Don't hesitate to claim your badge "El Translator" on `Badger platform <http://badger.akeneo.com/login/>`_!
 
 How it works
 ------------

--- a/cookbook/event/index.rst
+++ b/cookbook/event/index.rst
@@ -11,8 +11,8 @@ you can create your own `services`_ that interact with those objects whenever ce
 
 For more details about event listeners, you can read the `Symfony documentation`_
 
-.. _Symfony documentation: http://symfony.com/doc/current/cookbook/event_dispatcher/event_listener.html
-.. _services: http://symfony.com/doc/current/book/service_container.html
+.. _Symfony documentation: https://symfony.com/doc/2.7/event_dispatcher.html
+.. _services: https://symfony.com/doc/2.7/service_container.html
 
 Example
 -------

--- a/cookbook/import_export/create-connector.rst
+++ b/cookbook/import_export/create-connector.rst
@@ -33,7 +33,7 @@ Jobs and steps are actually Symfony services. The first thing we need is to decl
     Please note that in versions < 1.6, the file was named ``batch_jobs.yml`` and was automatically loaded.
     The file content was very strict, was less standard and upgradeable than it is now.
 
-.. _Symfony documentation: http://symfony.com/doc/2.7/bundles/extension.html#using-the-load-method
+.. _Symfony documentation: https://symfony.com/doc/2.7/bundles/extension.html#using-the-load-method
 
 As you can see there is almost no difference with the native CSV export job.
 The only new info here is the name (first parameter) and the connector name (the ``connector`` property of the tag).

--- a/cookbook/index.rst
+++ b/cookbook/index.rst
@@ -7,7 +7,7 @@ Cookbook
     If you are not familiar with one of these, the best move is to start by reading the `Symfony documentation`_ and `Doctrine documentation`_
 
 .. _Symfony documentation: https://symfony.com/doc/current/index.html
-.. _Doctrine documentation: http://doctrine-orm.readthedocs.org/en/latest/
+.. _Doctrine documentation: http://doctrine-orm.readthedocs.io/en/latest/
 
 .. toctree::
     :maxdepth: 2

--- a/cookbook/product_asset/add_asset_default_thumbnail_for_unknown_file_types.rst
+++ b/cookbook/product_asset/add_asset_default_thumbnail_for_unknown_file_types.rst
@@ -10,7 +10,7 @@ In the asset management each file type has a default image. Thus, if you add a n
 To add a default image for an unknown file type, you have to override a service and a parameter in the dependency injection.
 
 .. note::
-    Learn more about Symfony2 Dependency Injection in the documentation: http://symfony.com/doc/2.7/components/dependency_injection.html.
+    Learn more about Symfony2 Dependency Injection in the documentation: https://symfony.com/doc/2.7/components/dependency_injection.html.
 
 For the sake of the cookbook, we'll add a default thumbnail for audio type. Currently, if an audio file is added in Akeneo this image is shown:
 

--- a/cookbook/product_asset/add_new_transformation.rst
+++ b/cookbook/product_asset/add_new_transformation.rst
@@ -18,7 +18,7 @@ Then, you can find in ``Akeneo\Component\FileTransformer`` all business code and
 Transformation runs with the registry pattern. You have to create your own Transformation implementing ``Akeneo\Component\FileTransformer\Transformation\TransformationInterface`` and register the service with the ``akeneo_file_transformer.transformation`` tag.
 Then, compiler pass will inject your tagged Transformation in the registry which will make it available.
 
-.. _registry: http://martinfowler.com/eaaCatalog/registry.html
+.. _registry: https://martinfowler.com/eaaCatalog/registry.html
 .. note::
     Learn more about registry_ pattern.
 
@@ -171,7 +171,7 @@ In order to rely on options you can add an OptionsResolver, for this you need to
         }
     }
 
-.. _OptionsResolver: http://symfony.com/doc/2.7/components/options_resolver.html
+.. _OptionsResolver: https://symfony.com/doc/2.7/components/options_resolver.html
 .. note::
     You can learn more about this Symfony2 component in the OptionsResolver_ documentation.
 

--- a/cookbook/setup_data/add_translation_packs.rst
+++ b/cookbook/setup_data/add_translation_packs.rst
@@ -2,7 +2,7 @@
 How to Add Translation Packs
 ============================
 
-.. _Crowdin: http://crowdin.net/project/akeneo/
+.. _Crowdin: https://crowdin.net/project/akeneo/
 
 
 Akeneo PIM UI is translated through `Crowdin`_ (feel free to :doc:`/contributing/translate`!).

--- a/cookbook/ui_customization/add_a_new_tab_to_an_entity_edit_form.rst
+++ b/cookbook/ui_customization/add_a_new_tab_to_an_entity_edit_form.rst
@@ -131,7 +131,7 @@ You can now create your template ``/src/Acme/Bundle/EnrichBundle/Resources/views
 
 After a cache clear (``app/console cache:clear``) you should see something like this on the category edit form:
 
-As you can see, you will have to translate the tab title in your translations file (see http://symfony.com/doc/2.7/translation.html).
+As you can see, you will have to translate the tab title in your translations file (see https://symfony.com/doc/2.7/translation.html).
 
 As shown in the screenshot above, we have total access to the category edit form and we can now render our package section in this tab.
 

--- a/developer_guide/installation/installation_archive.rst.inc
+++ b/developer_guide/installation/installation_archive.rst.inc
@@ -14,7 +14,7 @@ Extracting the archive
     * For Community Edition, replace *pim-community-standard-v1.7-latest-icecat.tar.gz* by the location and the name
       of the archive you have downloaded from https://www.akeneo.com/download
     * For Enterprise Edition, replace *pim-community-standard-v1.7-latest-icecat.tar.gz* by the location and the name
-      of the archive you have downloaded from https://partners.akeneo.com
+      of the archive you have downloaded from `Partner portal <https://partners.akeneo.com/login>`_
 
 .. note::
     The PIM will be extracted in the folder /path/to/installation/pim-community-standard.
@@ -34,7 +34,7 @@ Initializing Akeneo
 
 Testing your installation
 -------------------------
-Go to http://akeneo-pim.local/ and log in with *admin/admin*. If you see the dashboard, congratulations, you have successfully installed Akeneo PIM! You can also access the dev environment on http://akeneo-pim.local/app_dev.php
+Access the `web` folder using your favorite web browser and log in with *admin/admin*. If you see the dashboard, congratulations, you have successfully installed Akeneo PIM! You can also access the dev environment on using `app_dev.php` as index.
 
 If an error occurs, it means that something went wrong in one of the previous steps. Please check error outputs of all the steps.
 

--- a/developer_guide/installation/installation_ce_archive.rst
+++ b/developer_guide/installation/installation_ce_archive.rst
@@ -9,7 +9,7 @@ Getting Akeneo PIM
 Downloading the archive
 ***********************
 
-You can choose to download a PIM Community Edition along with demo data (called *icecat*) or not (called *minimal*) from the download page http://www.akeneo.com/download.
+You can choose to download a PIM Community Edition along with demo data (called *icecat*) or not (called *minimal*) from the download page https://www.akeneo.com/download.
 You can also download them directly from the command line:
 
 .. code-block:: bash

--- a/developer_guide/installation/partners_portal_archive.rst.inc
+++ b/developer_guide/installation/partners_portal_archive.rst.inc
@@ -8,10 +8,10 @@ If you are a developer on the project you should request an account to access th
 
 Getting Enterprise Edition access via the Partners Portal
 *********************************************************
-By default `Composer <https://getcomposer.org/>`_ uses `packagist.org <https://www.packagist.org/>`_. to retrieve all open source packages and their updates.
+By default `Composer <https://getcomposer.org/>`_ uses `packagist.org <https://packagist.org/>`_. to retrieve all open source packages and their updates.
 To download the PIM Enterprise Edition, you have to get access to our private enterprise edition repository by sending your SSH public key to our systems.
 
-Login to the Partners Portal at https://partners.akeneo.com
+Login to the `Partners Portal <https://partners.akeneo.com/login>`_:
 
 * In your account go to manage public keys
 

--- a/developer_guide/installation/system_requirements/system_requirements.rst.inc
+++ b/developer_guide/installation/system_requirements/system_requirements.rst.inc
@@ -68,7 +68,7 @@ Besides these modules, the following configuration is the minimal configuration 
 
   Due to changes in its API, MongoDB 3.0 is not supported.
 
-.. _ONLY_FULL_GROUP_BY: http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_only_full_group_by
+.. _ONLY_FULL_GROUP_BY: https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_only_full_group_by
 
 .. warning::
 

--- a/developer_guide/migration/index.rst
+++ b/developer_guide/migration/index.rst
@@ -106,7 +106,7 @@ Here are the migration guides:
 
 **Enterprise Edition**
 
-Standard Enterprise Edition (EE) archives are now available on a dedicated portal: https://partners.akeneo.com/. You will be able to download your EE archive directly from it. If you do not have access to this interface, please contact your please contact your Customer Success or Channel Manager.
+Standard Enterprise Edition (EE) archives are now available on a `dedicated Partner portal <https://partners.akeneo.com/login>`_. You will be able to download your EE archive directly from it. If you do not have access to this interface, please contact your please contact your Customer Success or Channel Manager.
 
 Then, follow the migration guides located in your archive to upgrade your project.
 

--- a/reference/best_practices/core/behat.rst
+++ b/reference/best_practices/core/behat.rst
@@ -29,7 +29,7 @@ Install Firefox
 ---------------
 In order to use Selenium RC, you must actually install `firefox`_.
 
-.. _firefox: http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/32.0/
+.. _firefox: http://ftp.mozilla.org/pub/firefox/releases/32.0/
 
 
 Create a VirtualHost
@@ -126,4 +126,4 @@ You can also define which feature to run:
 
   > ~/git/pim-community-dev$ ./bin/behat features/product/edit_product.feature
 
-More details and options are available on http://behat.org/
+More details and options are available on `Behat website <http://behat.org/en/latest/>`_.

--- a/reference/best_practices/reusable_bundle.rst
+++ b/reference/best_practices/reusable_bundle.rst
@@ -55,8 +55,8 @@ You can find some configuration examples on our `Akeneo-Labs`_ projects (`scruti
 .. _Single Responsibility principle: https://en.wikipedia.org/wiki/Single_responsibility_principle
 .. _SOLID principles: https://en.wikipedia.org/wiki/SOLID_(object-oriented_design)
 .. _PMD: https://phpmd.org/
-.. _PhpSpec: http://phpspec.readthedocs.org/
-.. _Behat: http://docs.behat.org/
+.. _PhpSpec: http://phpspec.readthedocs.io/en/stable/
+.. _Behat: http://docs.behat.org/en/latest/
 .. _Travis: https://travis-ci.org/
 .. _Scrutinizer: https://scrutinizer-ci.com/
 .. _Akeneo-Labs: https://github.com/akeneo-labs
@@ -89,14 +89,14 @@ Use registries
 """"""""""""""
 Registries are also a good extension point when you have to deal with many cases (different attribute types, entities, etc.).
 They are used to gather related classes (i.e: filters, sorters).
-Simply declare it as a service and tag it (http://symfony.com/doc/2.7/components/dependency_injection/tags.html).
+Simply declare it as a service and `tag it <https://symfony.com/doc/2.7/service_container/tags.html>`_.
 
 .. note::
     Learn more about `registry`_ pattern.
 
 You can also follow the localizers' cookbook example: :doc:`/cookbook/localization/how_to_use_the_localizers`
 
-.. _registry: http://martinfowler.com/eaaCatalog/registry.html
+.. _registry: https://martinfowler.com/eaaCatalog/registry.html
 
 
 Plug on events (datagrid, savers, remover, etc.)
@@ -138,9 +138,9 @@ Two options:
 For your own model classes, create your class and its interface.
 Then you can rely on your interface and use the `Akeneo target resolver`_ which is based on the `Doctrine target entity resolver`_.
 
-.. _oneToOne unidirectional association: http://doctrine-orm.readthedocs.org/projects/doctrine-orm/en/latest/reference/association-mapping.html#one-to-one-unidirectional
+.. _oneToOne unidirectional association: https://doctrine-orm.readthedocs.io/projects/doctrine-orm/en/latest/reference/association-mapping.html#one-to-one-unidirectional
 .. _Akeneo target resolver: https://github.com/akeneo/pim-community-dev/blob/1.5/src/Pim/Bundle/CatalogBundle/DependencyInjection/Compiler/ResolveDoctrineTargetModelPass.php
-.. _Doctrine target entity resolver: http://symfony.com/doc/2.7/cookbook/doctrine/resolve_target_entity.html
+.. _Doctrine target entity resolver: https://symfony.com/doc/2.7/doctrine/resolve_target_entity.html
 
 
 Repositories
@@ -165,6 +165,6 @@ Remember never to use the `findAll()` method from a repository as you don't know
 On batch processes, don't forget to detach your objects from the Doctrine UnitOfWork and check the memory usage.
 You can use `blackfire`_ and `php-meminfo`_ to help you track memory leaks.
 
-.. _representative catalogs: http://docs.akeneo.com/latest/reference/scalability_guide/representative_catalogs.html
+.. _representative catalogs: /reference/scalability_guide/representative_catalogs`
 .. _blackfire: https://blackfire.io/docs/introduction
 .. _php-meminfo: https://github.com/BitOne/php-meminfo

--- a/reference/bundles/akeneo_labs_bundles.rst.inc
+++ b/reference/bundles/akeneo_labs_bundles.rst.inc
@@ -1,4 +1,4 @@
-.. _CustomEntityBundle: https://github.com/akeneo-labs/CustomEntityBundle.git
+.. _CustomEntityBundle: https://github.com/akeneo-labs/CustomEntityBundle
 
 +-------------------------+--------------------------------------------------------------------------------------------------------------------+
 | **Bundle**              | **Scope**                                                                                                          |

--- a/reference/bundles/pim_bundles.rst.inc
+++ b/reference/bundles/pim_bundles.rst.inc
@@ -1,23 +1,22 @@
-.. _AnalyticsBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/AnalyticsBundle
-.. _CatalogBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/CatalogBundle
-.. _CommentBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/CommentBundle
-.. _ConnectorBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/ConnectorBundle
-.. _DashboardBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/DashboardBundle
-.. _DataGridBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/DataGridBundle
-.. _EnrichBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/EnrichBundle
-.. _FilterBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/FilterBundle
-.. _ImportExportBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/ImportExportBundle
-.. _InstallerBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/InstallerBundle
-.. _JsFormValidationBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/JsFormValidationBundle
-.. _LocalizationBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/LocalizationBundle
-.. _NavigationBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/NavigationBundle
-.. _NotificationBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/NotificationBundle
-.. _PdfGeneratorBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/PdfGeneratorBundle
-.. _ReferenceDataBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/ReferenceDataBundle
-.. _UIBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/UIBundle
-.. _UserBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/UserBundle
-.. _VersioningBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/VersioningBundle
-.. _WebServiceBundle: https://github.com/akeneo/pim-community-dev/tree/master/src/Pim/Bundle/WebServiceBundle
+.. _AnalyticsBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/AnalyticsBundle
+.. _CatalogBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/CatalogBundle
+.. _CommentBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/CommentBundle
+.. _ConnectorBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/ConnectorBundle
+.. _DashboardBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/DashboardBundle
+.. _DataGridBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/DataGridBundle
+.. _EnrichBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/EnrichBundle
+.. _FilterBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/FilterBundle
+.. _ImportExportBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/ImportExportBundle
+.. _InstallerBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/InstallerBundle
+.. _JsFormValidationBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/JsFormValidationBundle
+.. _LocalizationBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/LocalizationBundle
+.. _NavigationBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/NavigationBundle
+.. _NotificationBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/NotificationBundle
+.. _PdfGeneratorBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/PdfGeneratorBundle
+.. _ReferenceDataBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/ReferenceDataBundle
+.. _UIBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/UIBundle
+.. _UserBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/UserBundle
+.. _VersioningBundle: https://github.com/akeneo/pim-community-dev/tree/1.7/src/Pim/Bundle/VersioningBundle
 
 +---------------------------+--------------------------------------------------------------------------------------------------------------------+
 | **Bundle**                | **Scope**                                                                                                          |
@@ -59,6 +58,4 @@
 | `UserBundle`_             | (introduced v1.0) Override OroUserBundle                                                                           |
 +---------------------------+--------------------------------------------------------------------------------------------------------------------+
 | `VersioningBundle`_       | (introduced v1.0) Versioning implementation for the PIM domain models                                              |
-+---------------------------+--------------------------------------------------------------------------------------------------------------------+
-| `WebServiceBundle`_       | (introduced v1.0) Very light Web Rest API (json format)                                                            |
 +---------------------------+--------------------------------------------------------------------------------------------------------------------+

--- a/reference/import_export/product-export.rst
+++ b/reference/import_export/product-export.rst
@@ -212,7 +212,7 @@ Here is another example:
 
 .. note::
 
-    You can find extra information about the Serializer component in the official Symfony documentation http://symfony.com/doc/2.7/components/serializer.html
+    You can find extra information about the Serializer component in the official Symfony documentation https://symfony.com/doc/2.7/components/serializer.html
 
 Product Writer
 --------------

--- a/reference/index.rst
+++ b/reference/index.rst
@@ -7,7 +7,7 @@ Reference
     If you are not familiar with one of these, the best move is to start by reading the `Symfony documentation`_ and `Doctrine documentation`_
 
 .. _Symfony documentation: https://symfony.com/doc/current/index.html
-.. _Doctrine documentation: http://doctrine-orm.readthedocs.org/en/latest/
+.. _Doctrine documentation: http://doctrine-orm.readthedocs.io/en/latest/
 
 .. toctree::
     :maxdepth: 2

--- a/reference/scalability_guide/index.rst
+++ b/reference/scalability_guide/index.rst
@@ -5,7 +5,7 @@ A product catalog is unique to one's need. It is configured with a custom number
 
 This chapter explains how we audit the application's scalability, it lists the known issues and possible improvements as well as the bottlenecks already encountered by our partners with the PIM. It also shows best practices you should implement to ensure the success of your project.
 
-We improve the scalability in each new minor version. If you encounter any new limitation, please do not hesitate to contact us through the forum http://akeneo.com/forums. We'll give you details about the roadmap for specific improvements and help you to find a suitable solution for your project.
+We improve the scalability in each new minor version. If you encounter any new limitation, please do not hesitate to contact us through `the forum <https://www.akeneo.com/forums>`_. We'll give you details about the roadmap for specific improvements and help you to find a suitable solution for your project.
 
 .. warning::
 

--- a/reference/scalability_guide/more_than_1GB_of_product_media_to_export.rst
+++ b/reference/scalability_guide/more_than_1GB_of_product_media_to_export.rst
@@ -40,7 +40,7 @@ Feel free to share it with the community!
 
 Here is an example of a working customization of the native archiver based on the Unix zip command and the Symfony `Process Component`_ :
 
-.. _`Process Component`: http://symfony.com/doc/2.7/components/process.html
+.. _`Process Component`: https://symfony.com/doc/2.7/components/process.html
 
 .. code-block:: php
 

--- a/reference/scalability_guide/more_than_64_indexes_with_mongodb.rst
+++ b/reference/scalability_guide/more_than_64_indexes_with_mongodb.rst
@@ -1,7 +1,7 @@
 More than 64 indexes with MongoDB?
 ----------------------------------
 
-A known limit of MongoDB is the number of indexes per collection https://docs.mongodb.org/manual/reference/limits/#Number-of-Indexes-per-Collection.
+A known limit of MongoDB is the number of indexes per collection https://docs.mongodb.com/manual/reference/limits/#Number-of-Indexes-per-Collection.
 
 The product documents are stored in a single collection and can be impacted by this limit.
 

--- a/reference/technical_information/recommended_configuration.rst
+++ b/reference/technical_information/recommended_configuration.rst
@@ -17,19 +17,20 @@ Hardware Minimum Configuration
 Software
 --------
 
-+-------------------+----------------------------------------------------------------------------+
-| Debian (Linux)    | 8 (64 bits)                                                                |
-+-------------------+----------------------------------------------------------------------------+
-| or Ubuntu         | 14.04 (64 bits)                                                            |
-+-------------------+----------------------------------------------------------------------------+
-| Apache Web Server | ≥ 2.4                                                                      |
-+-------------------+----------------------------------------------------------------------------+
-| PHP (CGI not FPM) | 5.6                                                                        |
-+-------------------+----------------------------------------------------------------------------+
-| MySQL             | 5.1 ≤ version ≤ 5.6 (sufficient for most projects, depending on volumetry) |
-+-------------------+----------------------------------------------------------------------------+
-| MongoDB           | 2.4 See `System Requirements`_ to determine wether you need it or not.     |
-+-------------------+----------------------------------------------------------------------------+
++-------------------+------------------------------------------------------------------------------------------------------------+
+| Debian (Linux)    | 8 (64 bits)                                                                                                |
++-------------------+------------------------------------------------------------------------------------------------------------+
+| or Ubuntu         | 14.04 (64 bits)                                                                                            |
++-------------------+------------------------------------------------------------------------------------------------------------+
+| Apache Web Server | ≥ 2.4                                                                                                      |
++-------------------+------------------------------------------------------------------------------------------------------------+
+| PHP (CGI not FPM) | 5.6                                                                                                        |
++-------------------+------------------------------------------------------------------------------------------------------------+
+| MySQL             | 5.1 ≤ version ≤ 5.6 (sufficient for most projects, depending on volumetry)                                 |
++-------------------+------------------------------------------------------------------------------------------------------------+
+| MongoDB           | 2.4 See :doc:`System Requirements </developer_guide/installation/system_requirements/system_requirements>` |
+|                   | to determine wether you need it or not.                                                                    |
++-------------------+------------------------------------------------------------------------------------------------------------+
 
 .. warning::
     For performance reasons, we recommend having the database on the same server on which import and export job will be run. Otherwise you will have potential network latency when communicating with the database instead of using a socket to communicate more efficiently.
@@ -44,5 +45,3 @@ If you need to host the application on a virtual machine, remember that dependin
 
   * The virtual CPUs (vCPUs) will not be equivalent of physical CPUs;
   * Read and write operations on the filesystem may be less efficient.
-
-.. _`System Requirements`: http://docs.akeneo.com/latest/developer_guide/installation/system_requirements/system_requirements.html

--- a/src/Acme/Bundle/InstallerBundle/DependencyInjection/AcmeInstallerExtension.php
+++ b/src/Acme/Bundle/InstallerBundle/DependencyInjection/AcmeInstallerExtension.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\Loader;
 /**
  * This is the class that loads and manages your bundle configuration
  *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ * To learn more see {@link https://symfony.com/doc/current/cookbook/bundles/extension.html}
  */
 class AcmeInstallerExtension extends Extension
 {

--- a/troubleshooting/bug_qualification/index.rst
+++ b/troubleshooting/bug_qualification/index.rst
@@ -63,7 +63,7 @@ When you notice slownesses, displaying pages and/or during import/exports, you a
 
 * Use the Symfony's profiler timeline tab to identify what part of the execution takes most of the time.
 * Use `blackfire.io <https://blackfire.io/>`_ in order to profile the requests which take too much time.
-* Use MySQL built in "SHOW PROCESSLIST" query to identify queries which take too long to run (See: `MySQL documentation: SHOW PROCESSLIST Syntax <http://dev.mysql.com/doc/refman/5.6/en/show-processlist.html>`_).
+* Use MySQL built in "SHOW PROCESSLIST" query to identify queries which take too long to run (See: `MySQL documentation: SHOW PROCESSLIST Syntax <https://dev.mysql.com/doc/refman/5.6/en/show-processlist.html>`_).
 * Use MEMINFO to analyse memory leak issues (See: `MEMINFO GitHub repository <https://github.com/BitOne/php-meminfo/>`_).
 
 Reporting the bug

--- a/troubleshooting/first_aid_kit/index.rst
+++ b/troubleshooting/first_aid_kit/index.rst
@@ -124,7 +124,7 @@ Disable all custom developments by commenting them in the "AppKernel.php" file `
 
 And then, re-apply `Step 7: are your assets properly deployed?`_ and `Step 8: did you clear the cache?`_
 
-Alternatively, you can check if the issue is reproducible on http://demo.akeneo.com (only for the latest PIM version).
+Alternatively, you can check if the issue is reproducible on `Demo website <http://demo.akeneo.com/user/login>`_ (only for the latest PIM version).
 
 Does the bug persist?
 ---------------------


### PR DESCRIPTION
Hello,

documentation was full of 404 links, this is bad for SEO but also for our beloved users.

So, I've fixed all links in for `1.7` branch, and added a test to avoid regressions.

Link of build is in platform.sh check or here => http://pr-574-mwwgyoa-u5qnvcnnxuvsm.eu.platform.sh/

Thanks for reviews
