### PR TITLE
Introduced deprecated version warning block

### DIFF
--- a/_themes/akeneo_rtd/layout.html
+++ b/_themes/akeneo_rtd/layout.html
@@ -92,10 +92,8 @@
 </head>
 
 <body class="wy-body-for-nav" role="document">
-
   {% block extrabody %} {% endblock %}
   <div class="wy-grid-for-nav">
-
     {# SIDE NAV, TOGGLES ON MOBILE #}
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
       <div class="wy-side-scroll">
@@ -144,7 +142,6 @@
     </nav>
 
     <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
-
       {# MOBILE NAV, TRIGGLES SIDE NAV ON TOGGLE #}
       <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
         <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
@@ -155,6 +152,16 @@
       {# PAGE CONTENT #}
       <div class="wy-nav-content">
         <div class="rst-content">
+          {% if theme_deprecated_version %}
+          <div class="rst-content akeneo-deprecated">
+            <div class="admonition warning">
+              <p class="first admonition-title">Caution</p>
+              <p>You are browsing the documentation for Akeneo in version <b>{{ version }}</b>, which is not maintained anymore.</p>
+              <p class="last">Consider upgrading to the <a href="https://docs.akeneo.com/latest/">latest version</a>.</p>
+            </div>
+          </div>
+          {% endif %}
+
           <div class="akeneo-search">
             {% include "searchbox.html" %}
           </div>

--- a/_themes/akeneo_rtd/layout.html
+++ b/_themes/akeneo_rtd/layout.html
@@ -157,7 +157,7 @@
             <div class="admonition warning">
               <p class="first admonition-title">Caution</p>
               <p>You are browsing the documentation for Akeneo in version <b>{{ version }}</b>, which is not maintained anymore.</p>
-              <p class="last">Consider upgrading to the <a href="https://docs.akeneo.com/latest/">latest version</a>.</p>
+              <p class="last"><span class="upgrade-now">Consider upgrading</span> to the <a href="https://docs.akeneo.com/latest/">latest version</a>.</p>
             </div>
           </div>
           {% endif %}

--- a/_themes/akeneo_rtd/static/css/akeneo.css
+++ b/_themes/akeneo_rtd/static/css/akeneo.css
@@ -149,3 +149,8 @@ a {
     overflow-y: auto;
     font-size:90%;
 }
+
+.akeneo-deprecated .last {
+    font-weight: bold;
+    font-size: 110%;
+}

--- a/_themes/akeneo_rtd/theme.conf
+++ b/_themes/akeneo_rtd/theme.conf
@@ -4,3 +4,4 @@ inherit = sphinx_rtd_theme
 [options]
 logo_only = True
 display_version = False
+deprecated_version = True


### PR DESCRIPTION
Hello, this fixes https://github.com/akeneo/pim-docs/issues/576.

As you know, we maintain - as of today - only versions 1.5+ of Akeneo. We should inform users they are using a deprecated version of Akeneo, motivating them to migrate: this is good for us and for the ecosystem :)
![capture](https://cloud.githubusercontent.com/assets/1247388/25855506/ab50e1ae-34d3-11e7-9436-2cc8e4de28f9.PNG)


