### PR TITLE
Displayed the contribution branch in built website

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -41,7 +41,7 @@ web:
       - /robots\.txt$
 
 # The size of the persistent disk of the application (in MB).
-disk: 128
+disk: 256
 
 # Build time dependencies.
 dependencies:
@@ -55,6 +55,8 @@ hooks:
       . .virtualenv/bin/activate
       # Platform.sh currently sets PIP_USER=1.
       export PIP_USER=
+      export PIM_VERSION=PLATFORM_BRANCH
+      export PIM_VERSIONS=PLATFORM_BRANCH
       pip install sphinx~=1.5.3
       pip install git+https://github.com/fabpot/sphinx-php.git
       pip install git+https://github.com/mickaelandrieu/sphinxcontrib.youtube.git


### PR DESCRIPTION
Thanks to environment variables, we can customize a little bit the build produced by platform.sh:

* remove the selector of versions
* configure the version to be the name of git branch

