### PR TITLE
Fix cookbook on category translation override

### DIFF
--- a/src/Acme/Bundle/CatalogBundle/Entity/TranslatableCategory.php
+++ b/src/Acme/Bundle/CatalogBundle/Entity/TranslatableCategory.php
@@ -19,4 +19,9 @@ class Category extends BaseCategory
 
         return $this;
     }
+
+    public function getTranslationFQCN()
+    {
+        return 'Acme\Bundle\CatalogBundle\Entity\CategoryTranslation';
+    }
 }


### PR DESCRIPTION
If adding a new translatable field to a category, one must override the `getTranslationFQCN` method so it returns the new `CategoryTranslation` class.