### PR TITLE
Remove OroRequireJSBundle from AppKernel.php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-php: 5.6
+php: 7.1
 
 sudo: false
 

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -167,7 +167,6 @@ class AppKernel extends Kernel
             new Oro\Bundle\ConfigBundle\OroConfigBundle(),
             new Oro\Bundle\DataGridBundle\OroDataGridBundle(),
             new Oro\Bundle\FilterBundle\OroFilterBundle(),
-            new Oro\Bundle\RequireJSBundle\OroRequireJSBundle(),
             new Oro\Bundle\SecurityBundle\OroSecurityBundle(),
             new Oro\Bundle\TranslationBundle\OroTranslationBundle(),
             new Oro\Bundle\UserBundle\OroUserBundle(),


### PR DESCRIPTION
This bundle does not exists anymore on `akeneo/pim-community-dev`, on master branch, and prevent documentation deployment.