### PR TITLE
Update minimal Mysql version supporting Json Type

### DIFF
--- a/install_pim/system_requirements/system_requirements.rst.inc
+++ b/install_pim/system_requirements/system_requirements.rst.inc
@@ -78,9 +78,9 @@ Besides these modules, the following configuration is the minimal configuration 
 
 **Database server**
 
-+-----------------+-----+
-| MySQL (SQL)     | 5.7 |
-+-----------------+-----+
++-----------------+----------+
+| MySQL (SQL)     | >= 5.7.8 |
++-----------------+----------+
 
 To use this database you will also require the distribution package:
 


### PR DESCRIPTION
Minimal version supporting Json Type is 5.7.8.

https://dev.mysql.com/doc/refman/5.7/en/json.html

As we use this feature, we should specify it in our system requirements.

Note: CI fixed in this PR https://github.com/akeneo/pim-docs/pull/656