### PR TITLE
Fixed `category code` to `option code`

### DIFF
--- a/import_and_export_data/formats/option.rst
+++ b/import_and_export_data/formats/option.rst
@@ -4,7 +4,7 @@ Options data structure
 Options are exported in a CSV file with the following structure:
 
 - **attribute** (required): the linked attribute code
-- **code** (required): the category code
+- **code** (required): the option code
 - **sort_order**: Option rank in the dropdown lists
 - **label-<locale_code>**: each label in a dedicated column (See :doc:`localized-labels`)
 


### PR DESCRIPTION
As I assume that `the category code` came from the "Category data structure" page, I fixed it to `option code` that is more relevant in the context.