### PR TITLE
Documentation to push jobs into the queue

### DIFF
--- a/import_and_export_data/guides/automate-import-exports.rst
+++ b/import_and_export_data/guides/automate-import-exports.rst
@@ -11,14 +11,14 @@ Akeneo PIM provides a simple command to launch jobs:
 .. code-block:: bash
     :linenos:
 
-    bin/console akeneo:batch:job [-c|--config CONFIG] [--email EMAIL] [--no-log] [--] <code>
+    bin/console akeneo:batch:publish-job-to-queue [-c|--config CONFIG] [--email EMAIL] [--no-log] [--] <code>
 
 So to run the job csv_product_import you can run:
 
 .. code-block:: bash
     :linenos:
 
-    bin/console akeneo:batch:job csv_product_import --env=prod
+    bin/console akeneo:batch:publish-job-to-queue csv_product_import --env=prod
 
 .. tip::
     Don't forget to add --env=prod to avoid memory leaks in dev environment (the default environment for commands)
@@ -28,7 +28,12 @@ You can also provide a custom configuration (in JSON format) for the job:
 .. code-block:: bash
     :linenos:
 
-    bin/console akeneo:batch:job csv_product_import -c "{\"filePath\": \"/custom/path/to/product.csv\"}" --env=prod
+    bin/console akeneo:batch:publish-job-to-queue csv_product_import -c "{\"filePath\": \"/custom/path/to/product.csv\"}" --env=prod
+
+.. warning::
+
+    One daemon or several daemon processes have to be started to execute the jobs.
+    Please follow the documentation :doc:`/install_pim/manual/daemon_queue` if it's not the case.
 
 Scheduling the jobs
 -------------------
@@ -56,6 +61,13 @@ You can now add a new line at the end of the opened file:
 .. code-block:: bash
     :linenos:
 
-    0 * * * * /home/akeneo/pim/bin/console akeneo:batch:job csv_product_import -c "{\"filePath\": \"/custom/path/to/product.csv\"}" --env=prod > /tmp/import.log
+    0 * * * * /home/akeneo/pim/bin/console akeneo:batch:publish-job-to-queue csv_product_import -c "{\"filePath\": \"/custom/path/to/product.csv\"}" --env=prod > /tmp/import.log
 
-With this cron configuration a product import will be launched every hour with the file `/custom/path/to/product.csv`
+With this cron configuration a product import will be pushed into the job queue every hour with the file `/custom/path/to/product.csv`.
+It will be processed as soon as a daemon process is pending for a new job to execute.
+Therefore, the execution of your job could be delayed.
+
+.. warning::
+
+    One daemon or several daemon processes have to be started to execute the jobs.
+    Please follow the documentation :doc:`/install_pim/manual/daemon_queue` if it's not the case.

--- a/import_and_export_data/guides/clean-csv-file-during-product-import.rst
+++ b/import_and_export_data/guides/clean-csv-file-during-product-import.rst
@@ -136,4 +136,9 @@ You can run the job from the UI or you can use following command:
 
 .. code-block:: bash
 
-    php bin/console akeneo:batch:job my_job_code
+    php bin/console akeneo:batch:publish-job-to-queue my_job_code --env=prod
+
+.. warning::
+
+    One daemon or several daemon processes have to be started to execute the jobs.
+    Please follow the documentation :doc:`/install_pim/manual/daemon_queue` if it's not the case.

--- a/import_and_export_data/guides/create-connector.rst
+++ b/import_and_export_data/guides/create-connector.rst
@@ -137,6 +137,17 @@ The ``--config`` option can be used to override the job instance parameters at r
 
     php bin/console akeneo:batch:job my_app_product_export --config='{"filePath":"\/tmp\/new_path.csv"}'
 
+.. warning::
+
+    In production, use this command instead:
+
+    .. code-block:: bash
+
+        php bin/console akeneo:batch:publish-job-to-queue my_app_product_export --env=prod
+
+    One daemon or several daemon processes have to be started to execute the jobs.
+    Please follow the documentation :doc:`/install_pim/manual/daemon_queue` if it's not the case.
+
 Configure the UI for our new job
 --------------------------------
 

--- a/import_and_export_data/guides/product-import-from-xml-file.rst
+++ b/import_and_export_data/guides/product-import-from-xml-file.rst
@@ -177,6 +177,17 @@ Now you can run the job from the UI or use the following command:
 
     php bin/console akeneo:batch:job xml_product_import
 
+.. warning::
+
+    In production, use this command instead:
+
+    .. code-block:: bash
+
+        php bin/console akeneo:batch:publish-job-to-queue my_app_product_export --env=prod
+
+    One daemon or several daemon processes have to be started to execute the jobs.
+    Please follow the documentation :doc:`/install_pim/manual/daemon_queue` if it's not the case.
+
 Adding support for invalid items export
 ---------------------------------------
 

--- a/install_pim/docker/installation_docker.rst
+++ b/install_pim/docker/installation_docker.rst
@@ -209,12 +209,10 @@ If you want to execute only one job:
 .. warning::
 
    Before stopping or destroying your containers, remember to first stop this daemon if you launched it in background, or you'll end up with a stuck FPM container, and will need to completely restart Docker.
-   The easiest way to do that is to use ``ps`` to find the process ID of your daemon, then kill it with the ``kill`` command as follow (1234 is here just an example):
 
    .. code-block:: bash
 
-      $ docker-compose exec fpm ps x
-      $ docker-compose exec fpm kill 1234
+      $ docker-compose exec fpm pkill -f job-queue-consumer-daemon
 
 
 Xdebug

--- a/install_pim/manual/daemon_queue.rst
+++ b/install_pim/manual/daemon_queue.rst
@@ -1,0 +1,101 @@
+Setting up the job queue daemon
+===============================
+
+Purpose of the queue
+--------------------
+
+Jobs launched from the UI or from the CLI are pushed into a `queue <https://en.wikipedia.org/wiki/Message_queue>`_ in order to be processed in background.
+
+One or several daemon processes have to be launched to execute the jobs.
+
+A daemon process can only execute one job at a time. The daemon process cannot execute any other job until the end of the current job.
+You can launch several daemon processes to execute multiple jobs in parallel.
+
+Also, the daemon processes could be run on several instance of the PIM, using the same MySQL database.
+
+This queue allows `horizontal scalability <https://en.wikipedia.org/wiki/Scalability#Horizontal_and_vertical_scaling>`_ of the PIM.
+Therefore, you can configure servers dedicated to the execution of the jobs.
+
+The command to launch a daemon is:
+
+.. code-block:: bash
+    :linenos:
+
+    $ /path/to/php /path/to/your/pim/bin/console akeneo:batch:job-queue-consumer-daemon --env=prod
+
+You can also run the daemon to execute only one job and then exit. This is useful for development purpose.
+
+.. code-block:: bash
+    :linenos:
+
+    $ /path/to/php /path/to/your/pim/bin/console akeneo:batch:job-queue-consumer-daemon --env=prod --run-once
+
+Logs
+----
+
+The daemon process writes logs to the standard output.
+It's your responsibility to choose where to write the logs.
+For example, to write in the file ``/tmp/daemon_logs.log``:
+
+.. code-block:: bash
+    :linenos:
+
+    $ /path/to/php /path/to/your/pim/bin/console akeneo:batch:job-queue-consumer-daemon --env=prod >/tmp/daemon_logs.log 2>&1
+
+Do note that you should ensure the log rotation as well.
+
+Supervisor
+----------
+
+It's strongly recommended to use a Process Control System to launch a daemon in production.
+This is not useful in development though.
+
+In this documentation, we will describe how to configure the Process Control System `supervisor <http://supervisord.org/index.html>`, to run a daemon process.
+These instructions are valid for Debian 9 and Ubuntu 16.04.
+
+Installing supervisor
+**********************
+
+Install `supervisor`:
+
+.. code-block:: bash
+    :linenos:
+
+    $ apt update
+    $ apt install supervisor
+
+For the other platforms, you can follow the `official documentation <http://supervisord.org/installing.html>`_.
+
+Configuring supervisor
+**********************
+
+Create a file in the configuration directory of supervisor ``/etc/supervisor/conf.d``.
+
+.. code-block:: bash
+    :linenos:
+
+    [program:akeneo_queue_daemon]
+    command=/path/to/php /path/to/your/pim/bin/console akeneo:batch:job-queue-consumer-daemon --env=prod
+    autostart=false
+    autorestart=true
+    stderr_logfile=/var/log/akeneo_daemon.err.log
+    stdout_logfile=/var/log/akeneo_daemon.out.log
+    user=my_user
+
+The user ``my_user`` should be the same as the user to run PHP-FPM.
+
+Then, bring the changes into effect:
+
+.. code-block:: bash
+    :linenos:
+
+    $ supervisorctl reread
+    $ supervisorctl update
+
+Launch the daemon
+*****************
+
+.. code-block:: bash
+    :linenos:
+
+    $ supervisorctl start akeneo_queue_daemon

--- a/install_pim/manual/index.rst
+++ b/install_pim/manual/index.rst
@@ -17,3 +17,4 @@ Once the requirements are fulfilled, you are ready to install Akeneo PIM. Otherw
 
    installation_ce_archive
    installation_ee_archive
+   daemon_queue

--- a/install_pim/manual/installation_archive.rst.inc
+++ b/install_pim/manual/installation_archive.rst.inc
@@ -57,6 +57,12 @@ Installation,
 
 .. include:: ./crontab_tasks.rst.inc
 
+Launching the daemon for job execution
+--------------------------------------
+
+Launch a daemon in order to execute the jobs.
+Please follow this documentation: :doc:`/install_pim/manual/daemon_queue`.
+
 Testing your installation
 -------------------------
 Access the `web` folder using your favorite web browser and log in with *admin/admin*. If you see the dashboard, congratulations, you have successfully installed Akeneo PIM! You can also access the dev environment using `app_dev.php` as index.

--- a/install_pim/manual/installation_archive_ee.rst.inc
+++ b/install_pim/manual/installation_archive_ee.rst.inc
@@ -58,6 +58,12 @@ Installation,
 
 .. include:: ./crontab_tasks_ee.rst.inc
 
+Launching the daemon for job execution
+--------------------------------------
+
+Launch a daemon in order to execute the jobs.
+Please follow this documentation: :doc:`/install_pim/manual/daemon_queue`.
+
 Testing your installation
 -------------------------
 Access the `web` folder using your favorite web browser and log in with *admin/admin*. If you see the dashboard, congratulations, you have successfully installed Akeneo PIM! You can also access the dev environment using `app_dev.php` as index.

--- a/manipulate_pim_data/product_asset/mass_import.rst
+++ b/manipulate_pim_data/product_asset/mass_import.rst
@@ -31,4 +31,9 @@ The job accepts a CSV file in the same format as the one below (delimiters and e
 In the profile configuration of the import job, you can specify the path to the assets CSV file on the server, so that this file is imported when the job is executed.
 
 Then, the job can be can ran with:
-``php bin/console akeneo:batch:job assets_mass_upload --env=prod``
+``php bin/console akeneo:batch:publish-job-to-queue assets_mass_upload --env=prod``
+
+.. warning::
+
+    One daemon or several daemon processes have to be started to execute the jobs.
+    Please follow the documentation :doc:`/install_pim/manual/daemon_queue` if it's not the case.


### PR DESCRIPTION
The command `akeneo:batch: job` should not be used anymore in production.
It should be only used in development.

Instead, the command `akeneo:batch:job-queue-consumer-daemon` should be used.