### PR TITLE
Update reference from npm to yarn

### DIFF
--- a/manipulate_pim_data/mass_edition/register_a_new_bulk_action.rst
+++ b/manipulate_pim_data/mass_edition/register_a_new_bulk_action.rst
@@ -277,6 +277,6 @@ Finally, you have to reinstall your assets:
     rm -rf var/cache/
     bin/console pim:install:assets
     bin/console assets:install --symlink
-    npm run webpack
+    yarn run webpack
 
 That's it! If you select several products then click "Bulk actions", your will be able to use your new feature.

--- a/manipulate_pim_data/mass_edition/register_a_new_bulk_action.rst
+++ b/manipulate_pim_data/mass_edition/register_a_new_bulk_action.rst
@@ -24,7 +24,8 @@ Any processor should have a ``process($item)`` method to process an entity. Here
 
     // src/Acme/Bundle/AppBundle/Connector/Processor/MassEdit/Product/AddCommentProcessor.php
     <?php
-    'use strict';
+
+    declare(strict_types=1);
 
     namespace Acme\Bundle\AppBundle\Connector\Processor\MassEdit\Product;
 


### PR DESCRIPTION
This PR updates a reference in the bulk actions guide from npm to yarn and fixes an error with declaring strict types
