### PR TITLE
Remove section about Elasticsearch requirement on Docker

### DIFF
--- a/install_pim/docker/installation_docker.rst
+++ b/install_pim/docker/installation_docker.rst
@@ -37,17 +37,6 @@ To accelerate the installation of the PIM dependencies, `Composer cache <https:/
 
 You need to be sure these folders exist on your host before launching the containers. If not, Docker will create them for you, but with root permissions, preventing the containers from accessing it. As a result, dependencies installation will fail.
 
-Elasticsearch
-*************
-
-To run the Elasticsearch container, you will need to `increase the MAX_MAP_COUNT Linux kernel setting <https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-cli-run-prod-mode>`_.
-Proceed as follows (first command will affect your current session, second one will make the change permanent):
-
-.. code-block:: bash
-
-   $ sudo sysctl -w vm.max_map_count=262144
-   $ echo "vm.max_map_count=262144" | sudo tee /etc/sysctl.d/elasticsearch.conf
-
 Getting Akeneo PIM
 ******************
 

--- a/migrate_pim/index.rst
+++ b/migrate_pim/index.rst
@@ -24,7 +24,7 @@ Run the composer update command:
 
     php composer.phar --prefer-dist update
 
-Be aware that your composer.json won't be updated and some dependencies might be missing or from an outdated version. 
+Be aware that your composer.json won't be updated and some dependencies might be missing or from an outdated version.
 
 You have to check whether the latest composer.json is different from your own. In this case you should backup your current composer.json and download the newest one beforehand.
 
@@ -122,13 +122,13 @@ Here are the migration guides:
 * `From v1.1 to v1.2`_
 * `From v1.0 to v1.1`_
 
-.. _From v1.6 to v1.7: https://github.com/akeneo/pim-community-standard/blob/1.7/UPGRADE-1.7.md
-.. _From v1.5 to v1.6: https://github.com/akeneo/pim-community-standard/blob/1.6/UPGRADE-1.6.md
-.. _From v1.4 to v1.5: https://github.com/akeneo/pim-community-standard/blob/1.5/UPGRADE-1.5.md
-.. _From v1.3 to v1.4: https://github.com/akeneo/pim-community-standard/blob/1.4/UPGRADE-1.4.md
-.. _From v1.2 to v1.3: https://github.com/akeneo/pim-community-standard/blob/1.3/UPGRADE-1.3.md
-.. _From v1.1 to v1.2: https://github.com/akeneo/pim-community-standard/blob/master/UPGRADE-1.1.md
-.. _From v1.0 to v1.1: https://github.com/akeneo/pim-community-standard/blob/master/UPGRADE-1.2.md
+.. _From v1.6 to v1.7: https://github.com/akeneo/pim-community-standard/blob/master/UPGRADE-1.7.md
+.. _From v1.5 to v1.6: https://github.com/akeneo/pim-community-standard/blob/master/UPGRADE-1.6.md
+.. _From v1.4 to v1.5: https://github.com/akeneo/pim-community-standard/blob/master/UPGRADE-1.5.md
+.. _From v1.3 to v1.4: https://github.com/akeneo/pim-community-standard/blob/master/UPGRADE-1.4.md
+.. _From v1.2 to v1.3: https://github.com/akeneo/pim-community-standard/blob/master/UPGRADE-1.3.md
+.. _From v1.1 to v1.2: https://github.com/akeneo/pim-community-standard/blob/master/UPGRADE-1.2.md
+.. _From v1.0 to v1.1: https://github.com/akeneo/pim-community-standard/blob/master/UPGRADE-1.1.md
 
 **Enterprise Edition**
 

--- a/technical_architecture/best_practices/reusable_bundle.rst
+++ b/technical_architecture/best_practices/reusable_bundle.rst
@@ -136,7 +136,7 @@ For your own model classes, create your class and its interface.
 Then you can rely on your interface and use the `Akeneo target resolver`_ which is based on the `Doctrine target entity resolver`_.
 
 .. _oneToOne unidirectional association: https://doctrine-orm.readthedocs.io/projects/doctrine-orm/en/latest/reference/association-mapping.html#one-to-one-unidirectional
-.. _Akeneo target resolver: https://github.com/akeneo/pim-community-dev/blob/1.5/src/Pim/Bundle/CatalogBundle/DependencyInjection/Compiler/ResolveDoctrineTargetModelPass.php
+.. _Akeneo target resolver: https://github.com/akeneo/pim-community-dev/blob/1.7/src/Pim/Bundle/CatalogBundle/DependencyInjection/Compiler/ResolveDoctrineTargetModelPass.php
 .. _Doctrine target entity resolver: https://symfony.com/doc/2.7/doctrine/resolve_target_entity.html
 
 


### PR DESCRIPTION
The warning about increasing the `MAX_MAP_COUNT` Linux kernel setting is now useless thanks to [aaa2000](https://github.com/aaa2000) [recent contribution](https://github.com/akeneo/pim-community-dev/pull/7473).