### PR TITLE
Be clear that only Elasticsearch 5 can be used

### DIFF
--- a/install_pim/manual/system_requirements/manual_system_installation_debian9.rst
+++ b/install_pim/manual/system_requirements/manual_system_installation_debian9.rst
@@ -61,10 +61,10 @@ For Enterprise Edition, please also install:
 
     $ apt install php7.1-imagick
 
-Elasticsearch 5.5+
-******************
+Elasticsearch 5.5 or 5.6
+************************
 
-The easiest way to install Elasticsearch 5.5+ is to use the `official vendor package <https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html#deb-key>`_:
+The easiest way to install Elasticsearch 5 is to use the `official vendor package <https://www.elastic.co/guide/en/elasticsearch/reference/5.5/deb.html#deb>`_:
 
 - first install the PGP key
 - then install the package via the official repository
@@ -80,7 +80,7 @@ The easiest way to install Elasticsearch 5.5+ is to use the `official vendor pac
 
 .. warning::
 
-   You will probably need to `increase the MAX_MAP_COUNT Linux kernel setting <https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html#deb-configuring>`_.
+   You will probably need to `increase the MAX_MAP_COUNT Linux kernel setting <https://www.elastic.co/guide/en/elasticsearch/reference/5.5/deb.html#deb-configuring>`_.
    Proceed as follow (first command will affect your current session, second one every boot of your machine):
 
    .. code-block:: bash

--- a/install_pim/manual/system_requirements/system_install_ubuntu_1604.rst
+++ b/install_pim/manual/system_requirements/system_install_ubuntu_1604.rst
@@ -43,10 +43,10 @@ For Enterprise Edition, please also install:
 
     $ apt install php7.1-imagick
 
-Elasticsearch 5.5+
-******************
+Elasticsearch 5.5 or 5.6
+************************
 
-The easiest way to install Elasticsearch 5.5+ is to use the `official vendor package <https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html#deb-key>`_:
+The easiest way to install Elasticsearch 5 is to use the `official vendor package <https://www.elastic.co/guide/en/elasticsearch/reference/5.5/deb.html#deb>`_:
 
 - first install the PGP key
 - then install the package via the official repository
@@ -62,7 +62,7 @@ The easiest way to install Elasticsearch 5.5+ is to use the `official vendor pac
 
 .. warning::
 
-   You will probably need to `increase the MAX_MAP_COUNT Linux kernel setting <https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html#deb-configuring>`_.
+   You will probably need to `increase the MAX_MAP_COUNT Linux kernel setting <https://www.elastic.co/guide/en/elasticsearch/reference/5.5/deb.html#deb-configuring>`_.
    Proceed as follow (first command will affect your current session, second one every boot of your machine):
 
    .. code-block:: bash

--- a/install_pim/manual/system_requirements/system_requirements.rst.inc
+++ b/install_pim/manual/system_requirements/system_requirements.rst.inc
@@ -104,9 +104,9 @@ and the following PHP modules:
 
 **Search engine**
 
-+---------------+---------------------+
-| Elasticsearch | 5.5 ≤ version < 6.0 |
-+---------------+---------------------+
++---------------+------------+
+| Elasticsearch | 5.5 or 5.6 |
++---------------+------------+
 
 and the following Java Runtime Environment version
 


### PR DESCRIPTION
Elasticsearch 6 is now out since a few weeks. However, Akeneo **cannot** work with it for now.

Problem is, our doc is refering to the latest Elasticsearch documentation/version, meaning as of now the 6.1n which cannot work. Some users are confused on the SUG, as we only state "Elasticsearch 5.5+", meaning 6.x could work.

This PR makes it clear that only Elasticsearch 5.5 or 5.6 should be used.