### PR TITLE
Update Elasticsearch requirements to 5.6

### DIFF
--- a/install_pim/manual/system_requirements/manual_system_installation_debian9.rst
+++ b/install_pim/manual/system_requirements/manual_system_installation_debian9.rst
@@ -61,10 +61,10 @@ For Enterprise Edition, please also install:
 
     $ apt install php7.1-imagick
 
-Elasticsearch 5.5 or 5.6
-************************
+Elasticsearch 5.6
+*****************
 
-The easiest way to install Elasticsearch 5 is to use the `official vendor package <https://www.elastic.co/guide/en/elasticsearch/reference/5.5/deb.html#deb>`_:
+The easiest way to install Elasticsearch 5.6 is to use the `official vendor package <https://www.elastic.co/guide/en/elasticsearch/reference/5.6/deb.html#deb>`_:
 
 - first install the PGP key
 - then install the package via the official repository
@@ -80,7 +80,7 @@ The easiest way to install Elasticsearch 5 is to use the `official vendor packag
 
 .. warning::
 
-   You will probably need to `increase the MAX_MAP_COUNT Linux kernel setting <https://www.elastic.co/guide/en/elasticsearch/reference/5.5/deb.html#deb-configuring>`_.
+   You will probably need to `increase the MAX_MAP_COUNT Linux kernel setting <https://www.elastic.co/guide/en/elasticsearch/reference/5.6/deb.html#deb-configuring>`_.
    Proceed as follow (first command will affect your current session, second one every boot of your machine):
 
    .. code-block:: bash

--- a/install_pim/manual/system_requirements/system_install_ubuntu_1604.rst
+++ b/install_pim/manual/system_requirements/system_install_ubuntu_1604.rst
@@ -43,10 +43,10 @@ For Enterprise Edition, please also install:
 
     $ apt install php7.1-imagick
 
-Elasticsearch 5.5 or 5.6
-************************
+Elasticsearch 5.6
+*****************
 
-The easiest way to install Elasticsearch 5 is to use the `official vendor package <https://www.elastic.co/guide/en/elasticsearch/reference/5.5/deb.html#deb>`_:
+The easiest way to install Elasticsearch 5.6 is to use the `official vendor package <https://www.elastic.co/guide/en/elasticsearch/reference/5.6/deb.html#deb>`_:
 
 - first install the PGP key
 - then install the package via the official repository
@@ -62,7 +62,7 @@ The easiest way to install Elasticsearch 5 is to use the `official vendor packag
 
 .. warning::
 
-   You will probably need to `increase the MAX_MAP_COUNT Linux kernel setting <https://www.elastic.co/guide/en/elasticsearch/reference/5.5/deb.html#deb-configuring>`_.
+   You will probably need to `increase the MAX_MAP_COUNT Linux kernel setting <https://www.elastic.co/guide/en/elasticsearch/reference/5.6/deb.html#deb-configuring>`_.
    Proceed as follow (first command will affect your current session, second one every boot of your machine):
 
    .. code-block:: bash

--- a/install_pim/manual/system_requirements/system_requirements.rst.inc
+++ b/install_pim/manual/system_requirements/system_requirements.rst.inc
@@ -104,9 +104,9 @@ and the following PHP modules:
 
 **Search engine**
 
-+---------------+------------+
-| Elasticsearch | 5.5 or 5.6 |
-+---------------+------------+
++---------------+-----+
+| Elasticsearch | 5.6 |
++---------------+-----+
 
 and the following Java Runtime Environment version
 


### PR DESCRIPTION
When installing Elasticsearch following our documentation, and Elasticsearch official documentation, one will end up with latest Elasticsearch 5 version, meaning the 5.6, and not the 5.5.

What's more, the platypus team now works with Elasticsearch 5.6, so it is time that we officialy state using Elasticsearch 5.6 in our documentation.

Last point, Elasticsearch 5.6 is the last 5.x release, the 6.x being the current releases (with which the PIM is not compatible).