### PR TITLE
Remove unavailable options in the menu configuration

### DIFF
--- a/cookbook/ui_customization/how_to_customize_menu.rst
+++ b/cookbook/ui_customization/how_to_customize_menu.rst
@@ -93,13 +93,8 @@ Here is the list of all available options for a tree:
     tree:
         <menu_alias>                            # menu alias
             type: <menu_type>                   # menu type code. Link to menu template section.
-            scope_type: <string>                # menu scope type identifier
-            read_only: <boolean>                # disable ability to edit menu in UI
-            max_nesting_level: <integer>        # menu max nesting level
-            merge_strategy: <strategy>          # node merge strategy. possible strategies are append|replace|move
             extras:                             # extra parameters for container renderer
                 brand: <string>
                 brandLink: <string>
             children:                           # submenu items
                 <links to items hierarchy>
-                position: <integer>             # menu item position


### PR DESCRIPTION
Following what is specified in the configuration definition, I removed the unavailable options. https://github.com/akeneo/pim-community-dev/blob/1.7/src/Oro/Bundle/NavigationBundle/DependencyInjection/Configuration.php#L136