### PR TITLE
Remove versions from conf.py

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -62,7 +62,7 @@ copyright = u'2013-'+ current_year +', Akeneo SAS'
 version = os.getenv('PIM_VERSION', '1.0')
 
 # Warning: These versions will be deleted on documentation deploy.
-versions = os.getenv('PIM_VERSIONS', 'master 2.3 2.2 2.1 2.0 1.7 1.6 1.5 1.4 1.3 1.2 1.1 1.0')
+versions = os.getenv('PIM_VERSIONS', 'master')
 html_context = {
     'versions': versions.split(' '),
     'css_files': [


### PR DESCRIPTION
It is useless as it is replaced during deployement. Only master will be kept to not have an empty string, but it would work even without it.

This way, we will never have to do this kind of PR from 1.0 till master again.