### PR TITLE
Deprecate 1.6 documentation

### DIFF
--- a/_themes/akeneo_rtd/layout.html
+++ b/_themes/akeneo_rtd/layout.html
@@ -77,7 +77,7 @@
 
   {# Keep modernizr in head - http://modernizr.com/docs/#installing #}
   <script src="{{ pathto('_static/js/modernizr.min.js', 1) }}"></script>
-  
+
   <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -88,7 +88,7 @@
   ga('send', 'pageview');
 
   </script>
-  
+
 </head>
 
 <body class="wy-body-for-nav" role="document">
@@ -142,6 +142,16 @@
       <div class="wy-nav-content">
         <div class="rst-content">
           <div class="akeneo-search">
+            {% if theme_deprecated_version %}
+            <div class="rst-content akeneo-deprecated">
+              <div class="admonition warning">
+                <p class="first admonition-title">Caution</p>
+                <p>You are browsing the documentation for Akeneo in version <b>{{ version }}</b>, which is not maintained anymore.</p>
+                <p class="last"><span class="upgrade-now">Consider upgrading</span> to the <a href="https://docs.akeneo.com/latest/">latest version</a>.</p>
+              </div>
+            </div>
+            {% endif %}
+
             {% include "searchbox.html" %}
           </div>
           {% include "breadcrumbs.html" %}


### PR DESCRIPTION
This will add the same deprecate notice that is already present on 1.5 and previous documentation branches.

![image](https://user-images.githubusercontent.com/5039018/37765736-52de61a4-2dc5-11e8-954c-d1b94d03a1ca.png)
