### PR TITLE
Add a deprecation notice on 2.1

### DIFF
--- a/_themes/akeneo/layout.html
+++ b/_themes/akeneo/layout.html
@@ -58,6 +58,8 @@
         table.table tbody { display: table; width: 100%; }
         code.docutils.literal.table, tt.docutils.literal.table { display: inline; }
         strong { font-weight: bold; }
+        .deprecation-notice { margin-top: 5px; margin-bottom: 20px; }
+        @media all and (max-width: 768px) { .deprecation-notice { margin-top: 60px; margin-bottom: 10px; }}
     </style>
 </head>
 <body data-spy="scroll" data-target="#navbar">
@@ -87,6 +89,12 @@
                     <input id="algolia-search" class="form-control" placeholder="Search whole doc">
                 </div>
             </form>
+        </div>
+        <div class="alert alert-warning warning deprecation-notice">
+            <div class="bg-warning text-center">
+                Caution! You are browsing the documentation for Akeneo in version <b>{{ version }}</b>, which is not maintained anymore.<br>
+                <strong>Consider upgrading to the <a href="https://docs.akeneo.com/latest/">latest version</a>.</strong>
+            </div>
         </div>
     </div>
 </nav>

--- a/_themes/akeneo/static/css/variables-43bf553955.css
+++ b/_themes/akeneo/static/css/variables-43bf553955.css
@@ -6722,7 +6722,7 @@ button.close {
   }
 }
 body {
-  padding-top: 60px;
+  padding-top: 180px;
   height: 100%;
   overflow-y: scroll;
   font-weight: 300;


### PR DESCRIPTION
This PR adds a deprecation notice for the 2.1 branch, like we already have on 1.6 and previous.
But with the 2.0, we changed the documentation theme, so the deprecation notice had to change, too.

This change will of course NOT be merged in 2.2 for now.

## Without deprecation notice

![screenshot-2018-4-3 akeneo pim in a nutshell akeneo pim documentation](https://user-images.githubusercontent.com/5039018/38261988-2e4f6bd4-376c-11e8-87a6-70570065d221.png)

## With deprecation notice

![screenshot-2018-4-3 akeneo pim in a nutshell akeneo pim documentation 1](https://user-images.githubusercontent.com/5039018/38262001-3a077430-376c-11e8-8b3f-5e596516801a.png)

## With deprecation notice, in mobile view

![screenshot-2018-4-3 akeneo pim in a nutshell akeneo pim documentation 2](https://user-images.githubusercontent.com/5039018/38262015-4524e136-376c-11e8-8acb-af3320441304.png)
