### PR TITLE
Update cron tasks CE

### DIFF
--- a/install_pim/manual/crontab_tasks.rst.inc
+++ b/install_pim/manual/crontab_tasks.rst.inc
@@ -17,18 +17,22 @@ You have to add these 2 commands to your local installation:
     php /path/to/installation/pim-community-standard/bin/console pim:completeness:calculate --env=prod    # recalculates the products completeness
     php /path/to/installation/pim-community-standard/bin/console pim:versioning:refresh --env=prod        # processes pending versions
 
-In the following example, these lines will run the completeness and versioning calculation every 15 minutes:
+In the following example, these lines will run the completeness calculation at 11pm and the versioning calculation at 5am every day:
 
 .. code-block:: bash
     :linenos:
 
     # m  h  dom  mon  dow  command
-    */15 *  *    *    *    php /path/to/installation/pim-community-standard/bin/console pim:completeness:calculate --env=prod > /path/to/installation/pim-community-standard/var/logs/calculate_completeness.log 2>&1
-    */15 *  *    *    *    php /path/to/installation/pim-community-standard/bin/console pim:versioning:refresh --env=prod > /path/to/installation/pim-community-standard/var/logs/refresh_versioning.log 2>&1
+    0 23  *    *    *    php /path/to/installation/pim-community-standard/bin/console pim:completeness:calculate --env=prod > /path/to/installation/pim-community-standard/var/logs/calculate_completeness.log 2>&1
+    0 5  *    *    *    php /path/to/installation/pim-community-standard/bin/console pim:versioning:refresh --env=prod > /path/to/installation/pim-community-standard/var/logs/refresh_versioning.log 2>&1
 
 .. note::
 
     ``> /path/to/installation/pim-community-standard/var/logs/calculate_completeness.log 2>&1`` is to redirect both stdout and stderr to your log file.
+
+.. note::
+
+    The completeness is already recalculated after an import, a mass action, after the rules are executed, after a family edition and after a product is saved.
 
 .. warning::
 


### PR DESCRIPTION
Many clients and partners are configuring a completeness and versioning calculations every 15mn, which has side effects like errors since several completeness calculation are run at the same time.
I've updated examples (advised the cron task to run once a day) and added a note saying that the completeness was after several tasks like import, mass action..