### PR TITLE
Add composer update command run for EE migration (1.7)

### DIFF
--- a/developer_guide/migration/index.rst
+++ b/developer_guide/migration/index.rst
@@ -64,6 +64,12 @@ We always tag both community and enterprise versions with aligned version number
 
 Using the exact patch version will avoid any local composer cache issue.
 
+Then run the composer update command:
+
+.. code-block:: bash
+
+    php composer.phar --prefer-dist update
+
 Then follow the same process as the one for the community edition:
 
 .. code-block:: bash


### PR DESCRIPTION
We had multiple tickets recently because some people don't know that they have to run composer update command to update their PIM in EE.