### PR TITLE
Add composer update command run for EE migration (2.0)

### DIFF
--- a/migrate_pim/index.rst
+++ b/migrate_pim/index.rst
@@ -78,8 +78,13 @@ We always tag both community and enterprise versions with aligned version number
 
 Using the exact patch version will avoid any local composer cache issue.
 
-Then follow the same process as the one for the community edition:
+Then run the composer update command:
 
+.. code-block:: bash
+
+    php composer.phar --prefer-dist update
+
+Then follow the same process as the one for the community edition:
 
 .. note::
 


### PR DESCRIPTION
We had multiple tickets recently because some people don't know that they have to run composer update command to update their PIM in EE.

To be also merged in 2.2 and 2.3 during pullup days