### PR TITLE
Added proper opcache configuration to improve performance

### DIFF
--- a/technical_architecture/technical_information/php_ini.rst.inc
+++ b/technical_architecture/technical_information/php_ini.rst.inc
@@ -21,6 +21,8 @@
     $ sudo vim /etc/php/7.1/fpm/php.ini
     memory_limit = 512M
     date.timezone = Etc/UTC
+    opcache.memory_consumption=256
+    opcache.max_accelerated_files=25000
 
 To avoid spending too much time on permission problems between the CLI user and the FPM user, a good practice is to use the same user for both of them.
 


### PR DESCRIPTION
If we leave the default configuration opcache is not utilized at it's best. 

Calling `opcache_get_status(false);` will return a `cache_full`. This will cause caches to be invalidated quite often. 

The issue comes from 2 points : 
- Akeneo actually needs nearly 200mb of space. so the default 64 is not enough.
- There is around 15K php file in an Akeneo project so we need to increase the number of files as well to be on the safe side. 

This has a non-negligible impact on performances but on my dev machine, I go from ~600ms to ~500ms for loading a product page. 

Let's note that if multiple php projects run on the same server these values need to take the sum of the needs of all projects. 

This should also be changed in the docker files. 