### PR TITLE
Add a "pre-version" notice for 2.3

### DIFF
--- a/_themes/akeneo/layout.html
+++ b/_themes/akeneo/layout.html
@@ -58,10 +58,9 @@
         table.table tbody { display: table; width: 100%; }
         code.docutils.literal.table, tt.docutils.literal.table { display: inline; }
         strong { font-weight: bold; }
-        /* Uncomment to activate deprecation
+        /* Remove to deactivate pre-version notice */
         .deprecation-notice { margin-top: 5px; margin-bottom: 20px; }
         @media all and (max-width: 768px) { .deprecation-notice { margin-top: 60px; margin-bottom: 10px; }}
-        */
     </style>
 </head>
 <body data-spy="scroll" data-target="#navbar">
@@ -92,14 +91,13 @@
                 </div>
             </form>
         </div>
-        <!-- Uncomment to activate deprecation
+        <!-- Remove to deactivate pre-version notice -->
         <div class="alert alert-warning warning deprecation-notice">
             <div class="bg-warning text-center">
-                Caution! You are browsing the documentation for Akeneo in version <b>{{ version }}</b>, which is not maintained anymore.<br>
-                <strong>Consider upgrading to the <a href="https://docs.akeneo.com/latest/">latest version</a>.</strong>
+                Caution! You are browsing the documentation for Akeneo in version <b>{{ version }}</b>, which is a pre-release version.<br>
+                <strong>Consider using the <a href="https://docs.akeneo.com/latest/">latest stable version</a>.</strong>
             </div>
         </div>
-        -->
     </div>
 </nav>
 

--- a/_themes/akeneo/static/css/variables-43bf553955.css
+++ b/_themes/akeneo/static/css/variables-43bf553955.css
@@ -6722,8 +6722,7 @@ button.close {
   }
 }
 body {
-  /*padding-top: 180px; Uncomment to activate deprecation and remove the line after */
-  padding-top: 60px;
+  padding-top: 180px; /* Set to 60px when deactivating pre-version notice */
   height: 100%;
   overflow-y: scroll;
   font-weight: 300;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5039018/40310456-22debe64-5d0d-11e8-99c7-2c8f29eb5b52.png)

To be removed when 2.3 is officialy released.

When merged in master, the "pre-version" will be replaced by "development version" (and will never be removed from `master`).