### PR TITLE
fix docker default IP

### DIFF
--- a/install_pim/docker/installation_docker.rst
+++ b/install_pim/docker/installation_docker.rst
@@ -109,7 +109,7 @@ Here is a ``docker-compose.override.yml`` example:
          PHP_IDE_CONFIG: 'serverName=pim-ce-cli'
          PHP_XDEBUG_ENABLED: 0
          PHP_XDEBUG_IDE_KEY: 'XDEBUG_IDE_KEY'
-         XDEBUG_CONFIG: 'remote_host=172.10.0.1' # This is Docker default IP, this should allow CLI debugging on most Linux system.
+         XDEBUG_CONFIG: 'remote_host=172.17.0.1' # This is Docker default IP, this should allow CLI debugging on most Linux system.
 
      mysql:
        ports:


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

Fix docker wrong default IP. It seems that only the master is concerned, i didn't find this block of documentation in the 2.3.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | -


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
