### PR TITLE
Fix the fixture folder name icecat-demo-dev to icecat_demo_dev

### DIFF
--- a/install_pim/customize_dataset/index.rst
+++ b/install_pim/customize_dataset/index.rst
@@ -2,10 +2,10 @@ How to customize the Dataset
 ============================
 
 Akeneo PIM ships with two datasets. They are located in ``vendor/akeneo/pim-community-dev/src/Pim/Bundle/InstallerBundle/Resources/fixtures``:
-* *icecat-demo-dev* to be able to take a look and play with the PIM with already preset families, categories, products, etc..
+* *icecat_demo_dev* to be able to take a look and play with the PIM with already preset families, categories, products, etc..
 * *minimal* to start a brand new blank PIM project
 
-Akeneo PIM ships with *icecat-demo-dev* enabled.
+Akeneo PIM ships with *icecat_demo_dev* enabled.
 
 Switching From Icecat to Minimal
 --------------------------------


### PR DESCRIPTION
**Description**

Fixture folder name is `src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev` (delimited with underscores).

Using of `icecat-demo-dev` leads to the installation error:
Installer data directory cannot be found.


**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
