### PR TITLE
Fix a typo: tag:register -> tab:register

### DIFF
--- a/design_pim/guides/add_a_tab_to_form.rst
+++ b/design_pim/guides/add_a_tab_to_form.rst
@@ -48,7 +48,7 @@ First, we need to create a form extension in our bundle:
         }
     );
 
-The triggered event `tag:register` automatically register a new tab and will add it to the product edit form column.
+The triggered event `tab:register` automatically register a new tab and will add it to the product edit form column.
 
 For now this is a dummy extension, but this is a good start!
 


### PR DESCRIPTION
**Description**

The paragraph below the code contained an obvious typo `tag:` while meant `tab:`.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
