### PR TITLE
Fix the property setter service name `pim_catalog.updater.property_setter`

### DIFF
--- a/manipulate_pim_data/product/update.rst
+++ b/manipulate_pim_data/product/update.rst
@@ -78,7 +78,7 @@ It's available as a service, you can fetch it from the container.
 
 .. code-block:: php
 
-    $propertySetter = $this->getContainer()->get('pim_catalog.updater.product_property_setter');
+    $propertySetter = $this->getContainer()->get('pim_catalog.updater.property_setter');
 
 Use the PropertySetterInterface
 -------------------------------


### PR DESCRIPTION
**Description**

The service `pim_catalog.updater.product_property_setter` doesn't exist. Instead we have the `pim_catalog.updater.property_setter` service.

I could assume that this is not a typo but an idea to make the service name more consistent with:
* pim_catalog.updater.product_property_adder
* pim_catalog.updater.product_property_remover
* pim_catalog.updater.product_property_copier

but at the moment it is called without the `product_` and leads to confusion trying to follow docs.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | -


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
