### PR TITLE
SDS-8961: Additional information on allowing more locales

### DIFF
--- a/technical_architecture/localization/change_pim_locale.rst
+++ b/technical_architecture/localization/change_pim_locale.rst
@@ -18,6 +18,14 @@ If you want to allow more locales, you can change the limit by overriding the pa
 
 In this example, you allow locales translated to more than 70%.
 
+You can set this parameter directly in your ``app/config/parameters.yml`` file or in one of your custom bundle resource file (for instance ``Acme/Bundle/AppBundle/Resources/config/one_of_your_config_file.yml``).
+
+The last thing you need to do to take this change into account is to clear the symfony cache.
+
+.. code-block:: php
+
+    bin/console cache:clear --env=prod
+
 How to improve translations
 ---------------------------
 


### PR DESCRIPTION
- Explain where to override
- Add clear cache indication

@see https://akeneo.atlassian.net/browse/SDS-8961

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Ok
| English Review and 1 GTM          | Ok


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
