### PR TITLE
Fix #956 - property_setter was not the correct service.

### DIFF
--- a/manipulate_pim_data/product/update.rst
+++ b/manipulate_pim_data/product/update.rst
@@ -78,7 +78,7 @@ It's available as a service, you can fetch it from the container.
 
 .. code-block:: php
 
-    $propertySetter = $this->getContainer()->get('pim_catalog.updater.product_property_setter');
+    $propertySetter = $this->getContainer()->get('pim_catalog.updater.property_setter');
 
 Use the PropertySetterInterface
 -------------------------------


### PR DESCRIPTION
**Description**

Fixes #956 with doc containing wrong service id. 
As defined here : https://github.com/akeneo/pim-community-dev/blob/2.3/src/Pim/Bundle/CatalogBundle/Resources/config/updaters.yml#L81

The fix needs to be applied to all 2.* versions of the documentation.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
