### PR TITLE
Enhance style of the documentation

### DIFF
--- a/_themes/akeneo/layout.html
+++ b/_themes/akeneo/layout.html
@@ -175,6 +175,7 @@
                 navbar.addClass('scroll');
             }
         });
+        $(window).scroll();
     });
 </script>
 

--- a/_themes/akeneo/layout.html
+++ b/_themes/akeneo/layout.html
@@ -91,22 +91,23 @@
                 </div>
             </form>
         </div>
-        <!-- Uncomment to activate deprecation
-       <div class="alert alert-warning warning deprecation-notice">
-           <div class="bg-warning text-center">
-               Caution! You are browsing the documentation for Akeneo in version <b>{{ version }}</b>, which is not maintained anymore.<br>
-               <strong>Consider upgrading to the <a href="https://docs.akeneo.com/latest/">latest version</a>.</strong>
-           </div>
-       </div>
-       -->
     </div>
+
+    <!-- Uncomment to activate deprecation
+    <div class="bg-warning text-warning text-center small" style="padding: 5px 0;">
+        <i class="fa fa-warning"></i>
+        Caution! You are browsing the documentation for Akeneo in version <b>master</b>, which is a development
+        version. <strong>Consider using the <a href="https://docs.akeneo.com/latest/">latest stable
+        version</a>.</strong>
+    </div>
+    -->
 </nav>
 
 <div id="mainContent" style="display: none">
     <div class="container">
         <div class="row">
             <div class="col-xs-12">
-                <h1>&nbsp;</h1>
+                <h1 class="super-title">&nbsp;</h1>
             </div>
         </div>
         <div class="row">

--- a/_themes/akeneo/static/css/variables-43bf553955.css
+++ b/_themes/akeneo/static/css/variables-43bf553955.css
@@ -6722,7 +6722,7 @@ button.close {
   }
 }
 body {
-  padding-top: 180px; /* Set to 60px when deactivating pre-version notice */
+  padding-top: 80px; /* Set to 50px when deactivating pre-version notice */
   height: 100%;
   overflow-y: scroll;
   font-weight: 300;
@@ -6735,7 +6735,7 @@ strong {
 }
 p,
 li {
-  line-height: 2;
+  line-height: 1.5;
 }
 .container {
   margin-bottom: 60px;
@@ -7520,7 +7520,11 @@ hr.big {
 }
 h1 {
   font-weight: bold;
-  margin-top: 75px;
+  margin-top: 25px;
+}
+h1.super-title {
+  color: #e0e0e0;
+  border-bottom: 1px solid #f5f5f5;
 }
 h2 {
   margin-top: 45px;


### PR DESCRIPTION
**Description**

While writing some documentation, I've updated a bit the style of the documentation to make it more compact and readable, nothing huge, just small tweaks:
- Line height is a bit smaller
- No more large space used for nothing
- Make deprecation notice smaller
- Fix bug of deprecation notice displaying shadow even when we didn't scroll

## Before
![before](https://user-images.githubusercontent.com/301169/47439984-9db50380-d7ad-11e8-925b-7d6857db1f5b.png)

## After
![after](https://user-images.githubusercontent.com/301169/47439990-a0aff400-d7ad-11e8-9ef8-4fb0caa63338.png)


**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
