### PR TITLE
Add mbstring extension to requirements

### DIFF
--- a/install_pim/manual/system_requirements/system_requirements.rst.inc
+++ b/install_pim/manual/system_requirements/system_requirements.rst.inc
@@ -30,35 +30,37 @@ The web server will also need the following libraries and modules:
 
 **PHP required modules and configuration**
 
-+----------------+---------------------------+
-| PHP            | 7.1                       |
-+----------------+---------------------------+
-| php-apcu       | apc.enable_cli=1          |
-+----------------+---------------------------+
-| php7.1-bcmath  | No specific configuration |
-+----------------+---------------------------+
-| php7.1-curl    | No specific configuration |
-+----------------+---------------------------+
-| php7.1-fpm     | No specific configuration |
-+----------------+---------------------------+
-| php7.1-gd      | No specific configuration |
-+----------------+---------------------------+
-| php7.1-intl    | No specific configuration |
-+----------------+---------------------------+
-| php7.1-mcrypt  | No specific configuration |
-+----------------+---------------------------+
-| php7.1-mysql   | No specific configuration |
-+----------------+---------------------------+
-| php7.1-soap    | No specific configuration |
-+----------------+---------------------------+
-| php7.1-xml     | No specific configuration |
-+----------------+---------------------------+
-| php7.1-zip     | No specific configuration |
-+----------------+---------------------------+
-| php-exif       | No specific configuration |
-+----------------+---------------------------+
-| php7.1-imagick | No specific configuration |
-+----------------+---------------------------+
++----------------+----------------------------+
+| PHP             | 7.1                       |
++----------------+----------------------------+
+| php-apcu        | apc.enable_cli=1          |
++----------------+----------------------------+
+| php7.1-bcmath   | No specific configuration |
++----------------+----------------------------+
+| php7.1-curl     | No specific configuration |
++----------------+----------------------------+
+| php7.1-fpm      | No specific configuration |
++----------------+----------------------------+
+| php7.1-gd       | No specific configuration |
++----------------+----------------------------+
+| php7.1-intl     | No specific configuration |
++----------------+----------------------------+
+| php7.1-mcrypt   | No specific configuration |
++----------------+----------------------------+
+| php7.1-mysql    | No specific configuration |
++----------------+----------------------------+
+| php7.1-soap     | No specific configuration |
++----------------+----------------------------+
+| php7.1-xml      | No specific configuration |
++----------------+----------------------------+
+| php7.1-zip      | No specific configuration |
++----------------+----------------------------+
+| php-exif        | No specific configuration |
++----------------+----------------------------+
+| php7.1-imagick  | No specific configuration |
++----------------+----------------------------+
+| php7.1-mbstring | No specific configuration |
++----------------+----------------------------+
 
 .. warning::
 


### PR DESCRIPTION
**Description**

Akeneo uses mb-functions, which are mostly covered by polyfills.
Functions like mb_ereg_replace() are not part of the polyfills,
but is still used by Akeneo.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | -
