### PR TITLE
Add constraints on code's attribute blacklist

### DIFF
--- a/import_and_export_data/formats/examples/attribute_properties.csv
+++ b/import_and_export_data/formats/examples/attribute_properties.csv
@@ -1,7 +1,7 @@
 code;;all types;"| Must be unique
 | Must only contain letters, numbers and underscores
 | Must be less than 255 characters long
-| Cannot be one of: id, associationTypes, categories, categoryId, completeness, enabled, family, groups, associations, products, scope, treeId, values, category
+| Cannot be one of: id, associationTypes, categories, categoryId, completeness, enabled, family, groups, associations, products, scope, treeId, values, category, parent, label, entity_type
 | Cannot end with “_products” or “_groups”"
 type;;all types;Must be a valid type (see table below)
 label-<locale_code>;;;


### PR DESCRIPTION
**Description**

Add forgotten constraints that currently exist in the PIM (in 2.3) for code's attribute.

CF https://github.com/akeneo/pim-community-dev/blob/a0f27d9673e5c58523e45c5ccde04462a755ff6f/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml#L78