### PR TITLE
Fix future deprecation notice

### DIFF
--- a/_themes/akeneo/layout.html
+++ b/_themes/akeneo/layout.html
@@ -94,11 +94,11 @@
     </div>
 
     <!-- Uncomment to activate deprecation
-    <div class="bg-warning text-warning text-center small" style="padding: 5px 0;">
-        <i class="fa fa-warning"></i>
-        Caution! You are browsing the documentation for Akeneo in version <b>master</b>, which is a development
-        version. <strong>Consider using the <a href="https://docs.akeneo.com/latest/">latest stable
-        version</a>.</strong>
+    <div class="alert alert-warning warning deprecation-notice">
+        <div class="bg-warning text-center">
+            Caution! You are browsing the documentation for Akeneo in version <b>{{ version }}</b>, which is not maintained anymore.<br>
+            <strong>Consider upgrading to the <a href="https://docs.akeneo.com/latest/">latest version</a>.</strong>
+        </div>
     </div>
     -->
 </nav>


### PR DESCRIPTION
**Description**

A deprecation notice was added but commented (so it does not appear yet) for when the 2.3 will be deprecated, but the content of the notice is wrong, and is the one of the `master` branch, saying it is a development version.

This PR updates the notice with the right message (same already present in 2.1 and 2.2).

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | -


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
