### PR TITLE
Replace deprecated method by correct one

### DIFF
--- a/design_pim/guides/create_a_new_filter_type.rst
+++ b/design_pim/guides/create_a_new_filter_type.rst
@@ -35,7 +35,7 @@ To create a custom filter, first we need to create a FilterProvider for our new 
         public function supports($element)
         {
             return $element instanceof AttributeInterface  &&
-                $element->getAttributeType() === 'pim_catalog_number' &&
+                $element->getType() === 'pim_catalog_number' &&
                 null !== $element->getNumberMin() &&
                 null !== $element->getNumberMax();
         }


### PR DESCRIPTION
**Description**
I follow the documentation in order to create [a custom filter](https://docs.akeneo.com/2.3/design_pim/guides/create_a_new_filter_type.html#declare-a-filter-provider-for-our-custom-filter).

The method getAttributeType used is annotated as deprecated :  Will be removed in 1.8. Please use getType() instead.

I don't know where is this version of Akeneo but the method getType actually exists and is not depreciated

My project is on Akeneo 2.3 but I saw that the file didn't changed since the tag 2.0.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed

PS : 
