### PR TITLE
Some supervisord configuration were missing regarding onboarder documentation

### DIFF
--- a/onboarder/index.rst
+++ b/onboarder/index.rst
@@ -14,6 +14,7 @@ Akeneo Onboarder
     prerequisites/index
     installation/index
     synchronization/index
+    troubleshooting/index
 
 .. toctree::
     :hidden:

--- a/onboarder/installation/index.rst
+++ b/onboarder/installation/index.rst
@@ -68,8 +68,7 @@ Here are two examples in order to define environment variables:
 
 .. warning::
 
-    All the following variables must be set in order to configure the Onboarder correctly.
-
+    All the following variables must be set in order to configure the Onboarder correctly for all entrypoints, all processes that runs the PIM code source.
 
 **Variables provided by the Akeneo team**
 

--- a/onboarder/synchronization/index.rst
+++ b/onboarder/synchronization/index.rst
@@ -60,7 +60,7 @@ You can use supervisor to run the ``worker`` as a daemonized process, supervisor
 
 .. note::
 
-    Supervisor documentation: http://supervisord.org/
+    Supervisor documentation: https://github.com/Supervisor/supervisor#documentation
 
 You want an infinite worker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/onboarder/synchronization/index.rst
+++ b/onboarder/synchronization/index.rst
@@ -31,13 +31,13 @@ Launch the message worker
 | The messages that are part of the synchronization process are queued.
 | The queue is consumed by a command line process called ``worker``.
 |
-| The worker has to always be launched as it polls the queue waiting for new messages to handle.
+| The worker as to always be launched as it polls the queue waiting for new messages to handle.
 
 
 You want a supervised worker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Add the following supervisor configuration (update the following example to your needs)
+You can use supervisor to run the ``worker`` as a daemonized process, supervisor will monitor this process and according to the configuration you'll define it will be autostarted and autorestarted.
 
 .. code-block:: bash
 
@@ -48,9 +48,19 @@ Add the following supervisor configuration (update the following example to your
     autostart=true
     autorestart=true
 
+.. warning::
+
+    By default the environment variable of the shell that is running the supervisord process will not propagate the environment variables to the process it monitor.
+    You've to configure :doc:`the mandatory environment variables </onboarder/installation/index>` that the akeneo/pim-onboarder bundle requires in the ``/etc/supervisor.conf`` file.
+
+.. code-block:: bash
+
+    [supervisord]
+    environment=GOOGLE_APPLICATION_CREDENTIALS="/srv/pim/serviceAccount.json",ONBOARDER_TOPIC_NAME_FOR_PUBLICATION_TO_MIDDLEWARE="middleware-topic-name",...
+
 .. note::
 
-    Supervisor documentation: https://github.com/Supervisor/supervisor#documentation
+    Supervisor documentation: http://supervisord.org/
 
 You want an infinite worker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/onboarder/synchronization/index.rst
+++ b/onboarder/synchronization/index.rst
@@ -31,7 +31,7 @@ Launch the message worker
 | The messages that are part of the synchronization process are queued.
 | The queue is consumed by a command line process called ``worker``.
 |
-| The worker as to always be launched as it polls the queue waiting for new messages to handle.
+| The worker has to always be launched as it polls the queue waiting for new messages to handle.
 
 
 You want a supervised worker
@@ -51,7 +51,7 @@ You can use supervisor to run the ``worker`` as a daemonized process, supervisor
 .. warning::
 
     By default the environment variable of the shell that is running the supervisord process will not propagate the environment variables to the process it monitor.
-    You've to configure :doc:`the mandatory environment variables </onboarder/installation/index>` that the akeneo/pim-onboarder bundle requires in the ``/etc/supervisor.conf`` file.
+    You have to configure :doc:`the mandatory environment variables </onboarder/installation/index>` that the akeneo/pim-onboarder bundle requires in the ``/etc/supervisor.conf`` file.
 
 .. code-block:: bash
 

--- a/onboarder/troubleshooting/index.rst
+++ b/onboarder/troubleshooting/index.rst
@@ -1,0 +1,19 @@
+Troubleshooting
+===============
+
+Running the job queue daemon command line leads to errors
+---------------------------------------------------------
+
+.. code-block:: bash
+
+    batch.ERROR: Encountered an error executing the step: No project ID was provided, and we were unable to detect a default project ID.
+
+If you encounter this kind of error in ``var/logs/*.log``, it's because the job queue daemon command line isn't aware of the mandatory environment variables needed to run the onboarder properly.
+
+If you launch this daemon :doc:`using supervisor configuration </install_pim/manual/daemon_queue>` as recommended by the PIM installation manual you have to configure :doc:`the mandatory environment variables </onboarder/installation/index>` that the akeneo/pim-onboarder bundle requires in the ``/etc/supervisor.conf`` file.
+
+.. code-block:: bash
+
+    [supervisord]
+    environment=GOOGLE_APPLICATION_CREDENTIALS="/srv/pim/serviceAccount.json",ONBOARDER_TOPIC_NAME_FOR_PUBLICATION_TO_MIDDLEWARE="middleware-topic-name",...
+

--- a/technical_architecture/events/storage_events.rst
+++ b/technical_architecture/events/storage_events.rst
@@ -1,7 +1,7 @@
 Storage events
 ==============
 
-.. _GenericEvent: http://api.symfony.com/3.3/Symfony/Component/EventDispatcher/GenericEvent.html
+.. _GenericEvent: https://github.com/symfony/symfony/blob/3.3/src/Symfony/Component/EventDispatcher/GenericEvent.php
 .. _RemoveEvent: https://github.com/akeneo/pim-community-dev/blob/2.0/src/Akeneo/Component/StorageUtils/Event/RemoveEvent.php
 
 Storage events are dispatched in the PIM when you manipulate data using the savers and removers services.

--- a/technical_architecture/events/workflow_events.rst
+++ b/technical_architecture/events/workflow_events.rst
@@ -99,7 +99,7 @@ When a product draft is deleted:
 
 This event is dispatched **before** a product draft status is set to "ready".
 
-**Event Class**: `GenericEvent <http://api.symfony.com/2.7/Symfony/Component/EventDispatcher/GenericEvent.html>`_
+**Event Class**: `GenericEvent <https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/EventDispatcher/GenericEvent.php>`_
 
 ``pimee_workflow.product_draft.post_ready``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -107,7 +107,7 @@ This event is dispatched **before** a product draft status is set to "ready".
 This event is dispatched **after** a product draft's status has been set to "ready" and saved to DB.
 The product draft now becomes a proposal, **ready to be reviewed**.
 
-**Event Class**: `GenericEvent <http://api.symfony.com/2.7/Symfony/Component/EventDispatcher/GenericEvent.html>`_
+**Event Class**: `GenericEvent <https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/EventDispatcher/GenericEvent.php>`_
 
 **Built-in PIM subscribers registered to this event**
 
@@ -122,7 +122,7 @@ Listener Class Name                                                             
 
 This event is dispatched **before** a product draft is approved.
 
-**Event Class**: `GenericEvent <http://api.symfony.com/2.7/Symfony/Component/EventDispatcher/GenericEvent.html>`_
+**Event Class**: `GenericEvent <https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/EventDispatcher/GenericEvent.php>`_
 
 ``pimee_workflow.product_draft.post_approve``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -130,7 +130,7 @@ This event is dispatched **before** a product draft is approved.
 This event is dispatched **after** a product draft has been approved.
 The product **is updated and saved** with the new values, and the product draft is removed or updated.
 
-**Event Class**: `GenericEvent <http://api.symfony.com/2.7/Symfony/Component/EventDispatcher/GenericEvent.html>`_
+**Event Class**: `GenericEvent <https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/EventDispatcher/GenericEvent.php>`_
 
 **Built-in PIM subscribers registered to this event**
 
@@ -146,7 +146,7 @@ Listener Class Name                                                             
 This event is dispatched **before** a product draft is **partially** approved.
 A partial approve is about a specific single change of the product draft.
 
-**Event Class**: `GenericEvent <http://api.symfony.com/2.7/Symfony/Component/EventDispatcher/GenericEvent.html>`_
+**Event Class**: `GenericEvent <https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/EventDispatcher/GenericEvent.php>`_
 
 ``pimee_workflow.product_draft.post_partial_approve``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -155,7 +155,7 @@ This event is dispatched **before** a product draft is **partially** approved.
 The product **is updated and saved** with the new values, and the product draft is removed or updated.
 A partial approve is about a specific single change of the product draft.
 
-**Event Class**: `GenericEvent <http://api.symfony.com/2.7/Symfony/Component/EventDispatcher/GenericEvent.html>`_
+**Event Class**: `GenericEvent <https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/EventDispatcher/GenericEvent.php>`_
 
 **Built-in PIM subscribers registered to this event**
 
@@ -170,7 +170,7 @@ Listener Class Name                                                             
 
 This event is dispatched **before** a product object is updated from draft values.
 
-**Event Class**: `GenericEvent <http://api.symfony.com/2.7/Symfony/Component/EventDispatcher/GenericEvent.html>`_
+**Event Class**: `GenericEvent <https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/EventDispatcher/GenericEvent.php>`_
 
 ``pimee_workflow.product_draft.post_apply``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -178,14 +178,14 @@ This event is dispatched **before** a product object is updated from draft value
 This event is dispatched **after** a product object has been updated from draft values.
 Note that **the product is not saved yet**, only the product object is updated.
 
-**Event Class**: `GenericEvent <http://api.symfony.com/2.7/Symfony/Component/EventDispatcher/GenericEvent.html>`_
+**Event Class**: `GenericEvent <https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/EventDispatcher/GenericEvent.php>`_
 
 ``pimee_workflow.product_draft.pre_refuse``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This event is dispatched **before** a product draft is refused.
 
-**Event Class**: `GenericEvent <http://api.symfony.com/2.7/Symfony/Component/EventDispatcher/GenericEvent.html>`_
+**Event Class**: `GenericEvent <https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/EventDispatcher/GenericEvent.php>`_
 
 ``pimee_workflow.product_draft.post_refuse``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -193,7 +193,7 @@ This event is dispatched **before** a product draft is refused.
 This event is dispatched **after** a product draft has been refused.
 The product draft is updated in the DB.
 
-**Event Class**: `GenericEvent <http://api.symfony.com/2.7/Symfony/Component/EventDispatcher/GenericEvent.html>`_
+**Event Class**: `GenericEvent <https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/EventDispatcher/GenericEvent.php>`_
 
 **Built-in PIM subscribers registered to this event**
 
@@ -209,7 +209,7 @@ Listener Class Name                                                             
 This event is dispatched **before** a product draft is **partially** refused.
 A partial refuse is about a specific single change of the product draft.
 
-**Event Class**: `GenericEvent <http://api.symfony.com/2.7/Symfony/Component/EventDispatcher/GenericEvent.html>`_
+**Event Class**: `GenericEvent <https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/EventDispatcher/GenericEvent.php>`_
 
 ``pimee_workflow.product_draft.post_partial_refuse``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -218,7 +218,7 @@ This event is dispatched **before** a product draft is **partially** refused.
 The product draft is removed or updated.
 A partial refuse is about a specific single change of the product draft.
 
-**Event Class**: `GenericEvent <http://api.symfony.com/2.7/Symfony/Component/EventDispatcher/GenericEvent.html>`_
+**Event Class**: `GenericEvent <https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/EventDispatcher/GenericEvent.php>`_
 
 **Built-in PIM subscribers registered to this event**
 
@@ -233,14 +233,14 @@ Listener Class Name                                                             
 
 This event is dispatched **before** a product draft is removed.
 
-**Event Class**: `GenericEvent <http://api.symfony.com/2.7/Symfony/Component/EventDispatcher/GenericEvent.html>`_
+**Event Class**: `GenericEvent <https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/EventDispatcher/GenericEvent.php>`_
 
 ``pimee_workflow.product_draft.post_remove``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This event is dispatched **after** a product draft has been removed.
 
-**Event Class**: `GenericEvent <http://api.symfony.com/2.7/Symfony/Component/EventDispatcher/GenericEvent.html>`_
+**Event Class**: `GenericEvent <https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/EventDispatcher/GenericEvent.php>`_
 
 **Built-in PIM subscribers registered to this event**
 


### PR DESCRIPTION

**Description**

A customer had errors when he ran the job queue daemon command line.

According to the official PIM installation procedure this daemon is configured to be ran / supervised by supervisord process.
According to the supervisord official documentation the environment variables of the shell which runs the supervisord main process are not shared with the processes it manage. They have to be explicitly written in the `/etc/supervisor.conf` configuration file.

This PR add this information and add a troubleshooting section to ease the search of this kind of errors through the docs.akeneo.com website.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
