### PR TITLE
CLOUD-1050: add chmod command to fix SFTP access

### DIFF
--- a/cloud_edition/flexibility_mode/docs/data_file_transfer.rst
+++ b/cloud_edition/flexibility_mode/docs/data_file_transfer.rst
@@ -11,7 +11,7 @@ By default, the username is **akeneosftp** and the port in use is **22**. Also n
 
 Permissions
 -----------
-If Akeneo, as an SSH user or as a PIM process creates files in the SFTP sub-directories, permissions have to be set so that SFTP users can rename or delete them.
+If Akeneo, as an SSH user or as a PIM process, creates files in the SFTP sub-directories, permissions have to be set so that SFTP users can rename or delete them.
 
 .. code-block:: bash
 

--- a/cloud_edition/flexibility_mode/docs/data_file_transfer.rst
+++ b/cloud_edition/flexibility_mode/docs/data_file_transfer.rst
@@ -1,11 +1,20 @@
-Data File Transfer
-==================
+File Transfer (SFTP)
+====================
 
-| Depending on your project needs, you may have to transfer data files from/to Akeneo Cloud Environment.
-|
-| Akeneo Flexibility can provide dedicated SFTP access to the environments.
-| This SFTP access is independent from the SSH access used by the integrator to deploy custom code.
-|
-| The SFTP access uses the **akeneosftp** user in a chroot.
-|
-| The chroot is accessible by the akeneo user (so by the PIM application too) from the **/data/transfer/pim** directory on the environment.
+Transfering files from and to your Akeneo Cloud Environment can be done using an SFTP access.
+
+This access can only be granted **upon request**, after a Cloud ticket has been created through the `helpdesk`_.
+
+Please note that this SFTP access is not related to the SSH access (*i.e: different credentials*) and is limited to one particular folder:  **/data/transfer/pim**.
+
+By default, the username is **akeneosftp** and the port in use is **22**. Also note that you can request multiple SFTP accesses.
+
+Permissions
+-----------
+If Akeneo, as an SSH user or as a PIM process creates files in the SFTP sub-directories, permissions have to be set so that SFTP users can rename or delete them.
+
+.. code-block:: bash
+
+    $ chmod u=rwX,g=rwXs,o= /data/transfert/pim/*
+
+.. _`helpdesk`: https://helpdesk.akeneo.com


### PR DESCRIPTION
**Description**

This adds the chmod command in order to fix SFTP access when subfolders have been created by the PIM inside the SFTP transfer zone.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
