### PR TITLE
Fetch versions in AJAX way

### DIFF
--- a/_themes/akeneo/_versions.html
+++ b/_themes/akeneo/_versions.html
@@ -1,3 +1,7 @@
+<script type="text/javascript">
+    updateVersions();
+</script>
+
 <li class="dropdown">
     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
         {% if version == 'master' %}
@@ -7,8 +11,9 @@
         {% endif %}
         <span class="caret"></span>
     </a>
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu" id="versions">
         <li class="dropdown-title">Versions</li>
+        <!-- This will be dropped if a '/versions.json' is found -->
         {% for version in versions %}
             <li>
                 <a href="/{{ version|e }}/index.html">

--- a/_themes/akeneo/static/js/versions.js
+++ b/_themes/akeneo/static/js/versions.js
@@ -1,0 +1,32 @@
+var getJSON = function(url, callback) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', url, true);
+    xhr.responseType = 'json';
+    xhr.onload = function() {
+        var status = xhr.status;
+        if (status === 200) {
+            callback(null, xhr.response);
+        } else {
+            callback(status, xhr.response);
+        }
+    };
+    xhr.send();
+};
+
+function updateVersions() {
+    getJSON('/versions.json',
+        function (err, data) {
+            if (err === null) {
+                var versionsDom = document.getElementById('versions');
+                versionsDom.innerHTML = '<li class="dropdown-title">Versions</li>';
+                data.forEach(function (version) {
+                    var node = document.createElement('li');
+                    var link = document.createElement('a');
+                    link.href = version.url;
+                    link.innerHTML = version.label;
+                    node.appendChild(link);
+                    versionsDom.appendChild(node);
+                });
+            }
+        });
+}

--- a/conf.py
+++ b/conf.py
@@ -74,7 +74,8 @@ html_context = {
     'script_files': [
         '_static/js/jquery.min.js',
         '_static/js/akeneostyle.js',
-        '_static/js/bootstrap.min.js'
+        '_static/js/bootstrap.min.js',
+        '_static/js/versions.js'
     ],
     'display_github': True,
     'github_user': 'akeneo',


### PR DESCRIPTION
Today, each time we release a new version, we have to redeploy the entire docs, because each version (since 1.0) have to contain links of docs from 1.0 to master.
To prevent this, and only construct the last docs branch, I propose to put a global file in the server root, like this:

```
[
  { "label": "master", "url": "/master/index.html" },
  { "label": "v3.1", "url": "/3.1/index.html" },
  { "label": "v3.0", "url": "/3.0/index.html" },
  { "label": "v2.3", "url": "/2.3/index.html" },
  { "label": "v2.2", "url": "/2.2/index.html" },
  { "label": "v2.1", "url": "/2.1/index.html" },
  { "label": "v2.0", "url": "/2.0/index.html" },
  { "label": "v1.7", "url": "/1.7/index.html" },
  { "label": "v1.6", "url": "/1.6/index.html" },
  { "label": "v1.5", "url": "/1.5/index.html" },
  { "label": "v1.4", "url": "/1.4/index.html" },
  { "label": "v1.3", "url": "/1.3/index.html" },
  { "label": "v1.2", "url": "/1.2/index.html" },
  { "label": "v1.1", "url": "/1.1/index.html" },
  { "label": "v1.0", "url": "/1.0/index.html" }
]
```

Each time we release a version, we only have to add a line in this file, and that's it.
This commit have to be rollback from master to 1.0 (with a little refactor in 1.7), then we will never talk about the build of these old non maintained versions.
