### PR TITLE
Add instructions on how to manage job consumers on Flex (2.0 thru 3.1)

### DIFF
--- a/cloud_edition/flexibility_mode/docs/partners.rst
+++ b/cloud_edition/flexibility_mode/docs/partners.rst
@@ -1,10 +1,8 @@
 Partners
 ========
 
-| On Flexiblity Mode, you also have access to custom aliases.
-| Those one allowed you to run commands with higher privileges like starting/restarting system daemons.
-|
-| Below the list of aliases:
+| On Flexiblity Mode, you have access to custom aliases that
+| allow you to run a limit set of commands with root privileges.
 
 +----------------------------+--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Alias                      | Argument                 | Action                                                                                                                                     |
@@ -15,7 +13,51 @@ Partners
 +----------------------------+--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | ``partners_php7.1-fpm``    | ``status|start|restart`` | Show status or start/restart php-fpm daemon (Command name can vary depending on php version)                                               |
 +----------------------------+--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
-| ``partners_supervisor``    | ``status|start|restart`` | Show status or start/restart supervisor daemon (Used for php daemon queue/pim batch)                                                       |
+| ``partners_clear_cache``   |                          | Clear PIM cache properly. Stops php-fpm and supervisor, deletes PIM cache folder, warms up PIM cache and restarts php-fpm and supervisor   |
 +----------------------------+--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
-| ``partners_clear_cache``   |                          | Clear properly PIM's cache (doctrine). Stop php-fpm and supervisor, delete PIM's cache folder, warmup PIM and start php-fpm and supervisor |
-+----------------------------+--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
+
+Queue management
+================
+
+Akeneo PIM uses a daemon to execute jobs (i.e: imports, exports, etc.) from a queue.
+
+This daemon is managed by ``systemd`` and allows multiple operations such as:
+
+- start/stop/restart a daemon
+- check the status of a daemon
+- see logs of a daemon
+
+Please note that, while the number of running job consumers is not enforced, it is not recommended
+to increase it above the server capability. Between 1 and 3 comsumers is recommended.
+
+Create a new daemon by starting a service with a **unique** identifier:
+
+.. code-block:: bash
+    :linenos:
+
+    # Launch the "first" daemon
+    service pim_job_queue@first start
+
+    # Launch the "foo" daemon
+    service pim_job_queue@foo start
+
+    # Check the status of the daemon
+    service pim_job_queue@first status
+
+    # Stop the daemon
+    service pim_job_queue@foo stop
+
+    # See real time logs for
+    journalctl --unit=pim_job_queue@second -f
+
+Useful commands
+---------------
+
+.. code-block:: bash
+    :linenos:
+
+    # check the status of all running queues
+    systemctl status 'pim_job_queue@*' --state=active
+
+    # see logs for job consumer "foo", append with "-f" for real time display.
+    journalctl --unit=pim_job_queue@foo -f

--- a/cloud_edition/flexibility_mode/docs/partners.rst
+++ b/cloud_edition/flexibility_mode/docs/partners.rst
@@ -35,20 +35,20 @@ Create a new daemon by starting a service with a **unique** identifier:
 .. code-block:: bash
     :linenos:
 
-    # Launch the "first" daemon
-    service pim_job_queue@first start
+    # Launch the daemon #1
+    partners_systemctl start pim_job_queue@1
 
-    # Launch the "foo" daemon
-    service pim_job_queue@foo start
+    # Launch the daemon #2
+    partners_systemctl start pim_job_queue@2
 
     # Check the status of the daemon
-    service pim_job_queue@first status
+    partners_systemctl status pim_job_queue@1
 
     # Stop the daemon
-    service pim_job_queue@foo stop
+    partners_systemctl stop pim_job_queue@1
 
-    # See real time logs for
-    journalctl --unit=pim_job_queue@second -f
+    # See real time logs for daemon #2
+    journalctl --unit=pim_job_queue@2 -f
 
 Useful commands
 ---------------
@@ -60,4 +60,4 @@ Useful commands
     systemctl status 'pim_job_queue@*' --state=active
 
     # see logs for job consumer "foo", append with "-f" for real time display.
-    journalctl --unit=pim_job_queue@foo -f
+    journalctl --unit=pim_job_queue@2 -f

--- a/install_pim/manual/daemon_queue.rst
+++ b/install_pim/manual/daemon_queue.rst
@@ -44,8 +44,8 @@ For example, to write in the file ``/tmp/daemon_logs.log``:
 
 Do note that you should ensure the log rotation as well.
 
-Supervisor
-----------
+Option #1 - Supervisor
+----------------------
 
 It's strongly recommended to use a Process Control System to launch a daemon in production.
 This is not useful in development though.
@@ -99,3 +99,72 @@ Launch the daemon
     :linenos:
 
     $ supervisorctl start akeneo_queue_daemon
+
+Option #2 - systemd
+-------------------
+
+If you prefer, you can use systemd, which will also allow for multiple daemons execution at the same time,
+logs management and auto restart in case of failure.
+
+Configuration file
+******************
+
+Create `/etc/systemd/system/pim_job_queue@.service`:
+
+.. code-block:: txt
+    :lineos:
+
+    [Unit]
+    Description=Akeneo PIM Job Queue Service (#%i)
+
+    [Service]
+    Type=service
+    User=akeneo
+    WorkingDirectory={{ pim_root_dir }}
+    ExecStart={{ pim_root_dir }}/bin/console akeneo:batch:job-queue-consumer-daemon --env=prod
+    After=apache2.service
+    Restart=always
+
+    [Install]
+    WantedBy=multi-user.target
+
+Manage the services
+*******************
+
+.. code-block:: bash
+    :lineos:
+
+    # use * if you want the operation to apply on all services.
+    systemctl [start|stop|restart|status] pim_job_queue@*
+
+    # start a pim job queue
+    systemctl start pim_job_queue@1
+
+    # start another one
+    systemctl start pim_job_queue@2
+
+    # check the logs in real time for daemon #2
+    journalctl --unit=pim_job_queue@2 -f
+
+
+Manage services by non-root users
+*********************************
+
+sytemctl is not useable by non-privileged users, if you want to allow a user `akeneo` for instance:
+
+.. code-blocks:: bash
+    :lineos:
+
+    apt install sudo
+    visudo
+
+You can then type in the following lines, depending on what commands you want to allow.
+
+.. code-blocks:: bash
+    :lineos:
+
+    akeneo ALL=(root) NOPASSWD: /bin/systemctl start pim_job_queue@*
+    akeneo ALL=(root) NOPASSWD: /bin/systemctl stop pim_job_queue@*
+    akeneo ALL=(root) NOPASSWD: /bin/systemctl status pim_job_queue@*
+    akeneo ALL=(root) NOPASSWD: /bin/systemctl restart pim_job_queue@*
+    akeneo ALL=(root) NOPASSWD: /bin/systemctl reload pim_job_queue@*

--- a/install_pim/manual/daemon_queue.rst
+++ b/install_pim/manual/daemon_queue.rst
@@ -111,8 +111,8 @@ Configuration file
 
 Create `/etc/systemd/system/pim_job_queue@.service`:
 
-.. code-block:: txt
-    :lineos:
+.. code-block:: ini
+    :linenos:
 
     [Unit]
     Description=Akeneo PIM Job Queue Service (#%i)
@@ -120,8 +120,8 @@ Create `/etc/systemd/system/pim_job_queue@.service`:
     [Service]
     Type=service
     User=akeneo
-    WorkingDirectory={{ pim_root_dir }}
-    ExecStart={{ pim_root_dir }}/bin/console akeneo:batch:job-queue-consumer-daemon --env=prod
+    WorkingDirectory=/path/to/akeneo/
+    ExecStart=/path/to/akeneo/bin/console akeneo:batch:job-queue-consumer-daemon --env=prod
     After=apache2.service
     Restart=always
 
@@ -132,7 +132,7 @@ Manage the services
 *******************
 
 .. code-block:: bash
-    :lineos:
+    :linenos:
 
     # use * if you want the operation to apply on all services.
     systemctl [start|stop|restart|status] pim_job_queue@*
@@ -152,16 +152,16 @@ Manage services by non-root users
 
 sytemctl is not useable by non-privileged users, if you want to allow a user `akeneo` for instance:
 
-.. code-blocks:: bash
-    :lineos:
+.. code-block:: bash
+    :linenos:
 
     apt install sudo
     visudo
 
 You can then type in the following lines, depending on what commands you want to allow.
 
-.. code-blocks:: bash
-    :lineos:
+.. code-block:: bash
+    :linenos:
 
     akeneo ALL=(root) NOPASSWD: /bin/systemctl start pim_job_queue@*
     akeneo ALL=(root) NOPASSWD: /bin/systemctl stop pim_job_queue@*

--- a/install_pim/manual/daemon_queue.rst
+++ b/install_pim/manual/daemon_queue.rst
@@ -103,13 +103,13 @@ Launch the daemon
 Option #2 - systemd
 -------------------
 
-If you prefer, you can use systemd, which will also allow for multiple daemons execution at the same time,
-logs management and auto restart in case of failure.
+If you prefer, you can use ``systemd``, which will also allow for multiple daemons to run at the same time,
+to have logs management and auto restart in case of failure.
 
 Configuration file
 ******************
 
-Create `/etc/systemd/system/pim_job_queue@.service`:
+Create ``/etc/systemd/system/pim_job_queue@.service``:
 
 .. code-block:: ini
     :linenos:
@@ -150,7 +150,7 @@ Manage the services
 Manage services by non-root users
 *********************************
 
-sytemctl is not useable by non-privileged users, if you want to allow a user `akeneo` for instance:
+``sytemctl`` is not useable by non-privileged users, if you want to allow a user ``akeneo``:
 
 .. code-block:: bash
     :linenos:

--- a/maintain_pim/scalability_guide/index.rst
+++ b/maintain_pim/scalability_guide/index.rst
@@ -5,7 +5,9 @@ A product catalog is unique to one's need. It is configured with a custom number
 
 This chapter explains how we audit the application's scalability, it lists the known issues and possible improvements as well as the bottlenecks already encountered by our partners with the PIM. It also shows best practices you should implement to ensure the success of your project.
 
-We improve the scalability in each new minor version. If you encounter any new limitation, please do not hesitate to contact us through `the forum <https://www.akeneo.com/forums>`_. We'll give you details about the roadmap for specific improvements and help you to find a suitable solution for your project.
+We improve the scalability in each new minor version.
+If you encounter any new limitation, please do not hesitate to contact us through `the helpdesk <https://helpdesk.akeneo.com>`_.
+We'll give you details about the roadmap for specific improvements and help you to find a suitable solution for your project.
 
 .. warning::
 


### PR DESCRIPTION
**Description**

On flexibility (PaaS) servers, supervisor will be replaced in favor of systemd which is native. This adds documentation on how to use the job consumer feature now.

See PR for Akeneo PIM 3.1+: https://github.com/akeneo/pim-docs/pull/1220

Changes valid for `2.0`, `2.1`, `2.2`, `2.3` and `3.0`.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
