### PR TITLE
PIM-8410: Fix how to add new properties to a category

### DIFF
--- a/manipulate_pim_data/category/add_new_properties_to_a_category.rst
+++ b/manipulate_pim_data/category/add_new_properties_to_a_category.rst
@@ -89,11 +89,17 @@ Firstly, you have to create your custom type by inheriting the CategoryType clas
 
 Then, you have to override the service definition of your form:
 
-.. literalinclude:: ../../src/Acme/Bundle/EnrichBundle/Resources/config/form_types.yml
-    :language: yaml
-    :prepend: # /src/Acme/Bundle/EnrichBundle/Resources/config/form_types.yml
-    :lines: 1-2
-    :linenos:
+.. code-block:: yaml
+
+    # /src/Acme/Bundle/EnrichBundle/Resources/config/form_types.yml
+    services:
+        pim_enrich.form.type.category:
+            class: 'Acme\Bundle\EnrichBundle\Form\Type\CategoryType'
+            arguments:
+                - '%pim_catalog.entity.category.class%'
+                - '%pim_catalog.entity.category_translation.class%'
+            tags:
+                - { name: form.type, alias: pim_category }
 
 Then, add this new file to your dependency injection extension:
 
@@ -105,6 +111,26 @@ Then, add this new file to your dependency injection extension:
         /** ... **/
         $loader->load('form_types.yml');
     }
+
+You also need to update the controller dependency injection:
+
+.. code-block:: yaml
+
+    # /src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
+    services:
+        pim_enrich.controller.category_tree.product:
+            class: 'Akeneo\Pim\Enrichment\Bundle\Controller\Ui\CategoryTreeController'
+            arguments:
+                - '@event_dispatcher'
+                - '@pim_user.context.user'
+                - '@pim_catalog.saver.category'
+                - '@pim_catalog.remover.category'
+                - '@pim_catalog.factory.category'
+                - '@pim_catalog.repository.category'
+                - '@oro_security.security_facade'
+                - { related_entity: product, form_type: 'Acme\Bundle\EnrichBundle\Form\Type\CategoryType', acl: pim_enrich_product, route: pim_enrich }
+            calls:
+                - [ setContainer, [ '@service_container' ] ]
 
 Then, don't forget to add your new field to the twig template:
 
@@ -123,7 +149,7 @@ Make sure you've registered the template properly inside ``form_types.yml``:
 .. literalinclude:: ../../src/Acme/Bundle/EnrichBundle/Resources/config/form_types.yml
     :language: yaml
     :prepend: # /src/Acme/Bundle/EnrichBundle/Resources/config/form_types.yml
-    :lines: 1-3
+    :lines: 1-2
     :linenos:
 
 For the form validation you will have to add a new validation file:
@@ -239,13 +265,14 @@ Then, you have to override the service definition of your form:
 .. code-block:: yaml
 
     # /src/Acme/Bundle/EnrichBundle/Resources/config/form_types.yml
-    pim_enrich.form.type.category:
-        class: 'Acme\Bundle\EnrichBundle\Form\Type\CategoryType'
-        arguments:
-            - '%pim_catalog.entity.category.class%'
-            - '%pim_catalog.entity.category_translation.class%'
-        tags:
-            - { name: form.type, alias: pim_category }
+    services:
+        pim_enrich.form.type.category:
+            class: 'Acme\Bundle\EnrichBundle\Form\Type\CategoryType'
+            arguments:
+                - '%pim_catalog.entity.category.class%'
+                - '%pim_catalog.entity.category_translation.class%'
+            tags:
+                - { name: form.type, alias: pim_category }
 
 Then, add this new file to your dependency injection extension:
 
@@ -263,19 +290,20 @@ You also need to update the controller dependency injection:
 .. code-block:: yaml
 
     # /src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
-    pim_enrich.controller.category_tree.product:
-        class: '%pim_enrich.controller.category_tree.class%'
-        arguments:
-            - '@event_dispatcher'
-            - '@pim_user.context.user'
-            - '@pim_catalog.saver.category'
-            - '@pim_catalog.remover.category'
-            - '@pim_catalog.factory.category'
-            - '@pim_catalog.repository.category'
-            - '@oro_security.security_facade'
-            - { related_entity: product, form_type: 'Acme\Bundle\EnrichBundle\Form\Type\CategoryType', acl: pim_enrich_product, route: pim_enrich }
-        calls:
-            - [ setContainer, [ '@service_container' ] ]
+    services:
+        pim_enrich.controller.category_tree.product:
+            class: 'Akeneo\Pim\Enrichment\Bundle\Controller\Ui\CategoryTreeController'
+            arguments:
+                - '@event_dispatcher'
+                - '@pim_user.context.user'
+                - '@pim_catalog.saver.category'
+                - '@pim_catalog.remover.category'
+                - '@pim_catalog.factory.category'
+                - '@pim_catalog.repository.category'
+                - '@oro_security.security_facade'
+                - { related_entity: product, form_type: 'Acme\Bundle\EnrichBundle\Form\Type\CategoryType', acl: pim_enrich_product, route: pim_enrich }
+            calls:
+                - [ setContainer, [ '@service_container' ] ]
 
 Then, don't forget to add your new field to the twig template:
 

--- a/src/Acme/Bundle/EnrichBundle/Form/Type/CategoryType.php
+++ b/src/Acme/Bundle/EnrichBundle/Form/Type/CategoryType.php
@@ -2,6 +2,7 @@
 
 namespace Acme\Bundle\EnrichBundle\Form\Type;
 
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 use Akeneo\Pim\Enrichment\Bundle\Form\Type\CategoryType as BaseCategoryType;
@@ -18,7 +19,7 @@ class CategoryType extends BaseCategoryType
     {
         parent::buildForm($builder, $options);
 
-        $builder->add('description', 'text',
+        $builder->add('description', TextType::class,
             [
                 'required' => true
             ]

--- a/src/Acme/Bundle/EnrichBundle/Form/Type/ColorType.php
+++ b/src/Acme/Bundle/EnrichBundle/Form/Type/ColorType.php
@@ -2,6 +2,7 @@
 
 namespace Acme\Bundle\EnrichBundle\Form\Type;
 
+use Akeneo\Platform\Bundle\UIBundle\Form\Type\TranslatableFieldType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -19,7 +20,7 @@ class ColorType extends AbstractType
             ->add('code')
             ->add(
                 'label',
-                'pim_translatable_field',
+                TranslatableFieldType::class,
                 array(
                     'field'             => 'label',
                     'translation_class' => 'Acme\Bundle\CatalogBundle\Entity\ColorTranslation',

--- a/src/Acme/Bundle/EnrichBundle/Form/Type/TranslatableCategoryType.php
+++ b/src/Acme/Bundle/EnrichBundle/Form/Type/TranslatableCategoryType.php
@@ -5,6 +5,8 @@ namespace Acme\Bundle\EnrichBundle\Form\Type;
 use Symfony\Component\Form\FormBuilderInterface;
 
 use Akeneo\Pim\Enrichment\Bundle\Form\Type\CategoryType as BaseCategoryType;
+use Akeneo\Platform\Bundle\UIBundle\Form\Type\TranslatableFieldType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 
 /**
  * Type for category properties
@@ -20,13 +22,13 @@ class CategoryType extends BaseCategoryType
 
         $builder->add(
             'description',
-            'pim_translatable_field',
+            TranslatableFieldType::class,
             [
                 'field'             => 'description',
                 'translation_class' => $this->translationDataClass,
                 'entity_class'      => $this->dataClass,
                 'property_path'     => 'translations',
-                'widget'            => 'textarea',
+                'widget'            => TextareaType::class,
             ]
         );
     }

--- a/src/Acme/Bundle/EnrichBundle/Resources/config/form_types.yml
+++ b/src/Acme/Bundle/EnrichBundle/Resources/config/form_types.yml
@@ -1,5 +1,4 @@
 parameters:
-    pim_enrich.form.type.category.class: Acme\Bundle\EnrichBundle\Form\Type\CategoryType
     pim_enrich.view_element.category.tab.property.template: 'AcmeEnrichBundle:CategoryTree:Tab/property.html.twig'
 
 services:


### PR DESCRIPTION
The field type "pim_translatable_field" and the widget option don't exist anymore as a string value, but as a class name in the form type builder.