### PR TITLE
Clarified how to upgrade 1.7.X to a 2.X.X.

### DIFF
--- a/migrate_pim/upgrade_major_version.rst
+++ b/migrate_pim/upgrade_major_version.rst
@@ -7,7 +7,7 @@ These new major versions bring new features and larger changes to answer clients
 Migrate from 1.7 to 2.X
 ------------------------------
 
-To migrate from 1.7 to 2.X.X you need to install version 2.0.X first.
+To migrate from 1.7 to 2.X.X you need to first create a new akeneo instance with version 2.0.X.
 Then we recomend using the migration tool `Transporteo`_.
 
 .. _Transporteo: https://github.com/akeneo/transporteo

--- a/migrate_pim/upgrade_major_version.rst
+++ b/migrate_pim/upgrade_major_version.rst
@@ -4,14 +4,15 @@ How to upgrade to a major version?
 We release a major version each year.
 These new major versions bring new features and larger changes to answer clients growing needs.
 
-Migrate from 1.7 to 2.0
+Migrate from 1.7 to 2.X
 ------------------------------
 
-To migrate from 1.7 to 2.0, we recommend the use of our brand new migration tool `Transporteo`_.
+To migrate from 1.7 to 2.X.X you need to install version 2.0.X first.
+Then we recomend using the migration tool `Transporteo`_.
 
 .. _Transporteo: https://github.com/akeneo/transporteo
 
-We're continuously improving Transporteo to cover more and more use cases and automate more and more the migrations.
+Then it is necessary to do the progressively upgrade process to each 2.X version.
 
 Migrate from 2.3 to 3.0
 ------------------------------


### PR DESCRIPTION
Transporteo requires the minimum version to be 2.0.x. So you have to install 2.0.x first and then progressively update. Unless somebody can tell me you can go from 2.0 to 2.3 directly ?

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/3.0/.github/CONTRIBUTING.md) --->

**Description**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
