### PR TITLE
AOB-618 update the onboarder extension version from 2.1 to 2.2

### DIFF
--- a/onboarder/installation/index.rst
+++ b/onboarder/installation/index.rst
@@ -13,7 +13,7 @@ Execute the following composer commands to require the bundle:
 .. code-block:: bash
 
     composer config repositories.onboarder '{"type": "vcs", "url": "ssh://git@distribution.akeneo.com:443/pim-onboarder", "branch": "master"}'
-    composer require "akeneo/pim-onboarder" "2.1.*"
+    composer require "akeneo/pim-onboarder" "2.2.*"
 
 
 Enable the extension


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/3.0/.github/CONTRIBUTING.md) --->

**Description**

Minimum version for the 3.0 pim is now the 2.2.*
<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
