### PR TITLE
Fix for not translated parameter

### DIFF
--- a/src/Acme/Bundle/NotifyConnectorBundle/Resources/config/providers.yml
+++ b/src/Acme/Bundle/NotifyConnectorBundle/Resources/config/providers.yml
@@ -1,6 +1,6 @@
 services:
     acme_notifyconnector.provider.form.job_instance:
-        class: '%pim_enrich.provider.form.job_instance.class%'
+        class: 'Akeneo\Platform\Bundle\ImportExportBundle\Provider\Form\JobInstanceFormProvider'
         arguments:
             -
                 csv_product_export_notify: pim-job-instance-csv-product-export-notify


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/3.0/.github/CONTRIBUTING.md) --->

**Description**

<!--- (What does this Pull Request do? reference the related issue?) --->
In 3.1 key %pim_enrich.provider.form.job_instance.class% is not translated anywhere, in previous version it pointed to Akeneo\Platform\Bundle\ImportExportBundle\Provider\Form\JobInstanceFormProvider. Without the change following the cookbook yields 504 error.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
