### PR TITLE
Fix service definition for job consumer

### DIFF
--- a/install_pim/manual/daemon_queue.rst
+++ b/install_pim/manual/daemon_queue.rst
@@ -116,13 +116,13 @@ Create ``/etc/systemd/system/pim_job_queue@.service``:
 
     [Unit]
     Description=Akeneo PIM Job Queue Service (#%i)
+    After=apache2.service
 
     [Service]
-    Type=service
+    Type=simple
     User=akeneo
     WorkingDirectory=/path/to/akeneo/
     ExecStart=/path/to/akeneo/bin/console akeneo:batch:job-queue-consumer-daemon --env=prod
-    After=apache2.service
     Restart=always
 
     [Install]


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/3.0/.github/CONTRIBUTING.md) --->

**Description**

Fix service definition for the job consumer on PIM 2.x

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
