### PR TITLE
DAPI-435: add the push structure and product CRON definition into PIM…

### DIFF
--- a/cloud_edition/flexibility_mode/docs/crontasks.rst
+++ b/cloud_edition/flexibility_mode/docs/crontasks.rst
@@ -66,7 +66,7 @@ If you don't want to use this wrapper you can prepend `SHELL=/bin/bash`, for exa
     #Ansible: pimee:franklin-insights:fetch-products
     */30 * * * * pimee:franklin-insights:fetch-products --env=prod
     #Ansible: pimee:franklin-insights:quality-highlights:push-structure-and-products
-    15 */12 * * * * pimee:franklin-insights:quality-highlights:push-structure-and-products --env=prod
+    15 0,12 * * * * pimee:franklin-insights:quality-highlights:push-structure-and-products --env=prod
     #Ansible: akeneo:reference-entity:refresh-records --all
     0 23 * * * akeneo:reference-entity:refresh-records --all --env=prod
 
@@ -129,7 +129,7 @@ Enterprise Edition specific crontab:
 +-----------------------------------------------------------------------------------+----------------------+-------------------------------------------+
 | pimee:franklin-insights:fetch-products --env=prod                                 | \*/30 \* \* \* \*    | Every 30 minutes                          |
 +-----------------------------------------------------------------------------------+----------------------+-------------------------------------------+
-| pimee:franklin-insights:quality-highlights:push-structure-and-products --env=prod | 15 \*/12 \* \* \* \* | Every 12 hours past 15 minutes            |
+| pimee:franklin-insights:quality-highlights:push-structure-and-products --env=prod | 15 0,12 \* \* \* \*  | At 12:15 AM and 12:15 PM                  |
 +-----------------------------------------------------------------------------------+----------------------+-------------------------------------------+
 | akeneo:reference-entity:refresh-records --all --env=prod                          | 0 23 \* \* \*        | At 11:00 PM                               |
 +-----------------------------------------------------------------------------------+----------------------+-------------------------------------------+

--- a/cloud_edition/flexibility_mode/docs/crontasks.rst
+++ b/cloud_edition/flexibility_mode/docs/crontasks.rst
@@ -65,6 +65,8 @@ If you don't want to use this wrapper you can prepend `SHELL=/bin/bash`, for exa
     0 2 * * * pimee:project:recalculate --env=prod
     #Ansible: pimee:franklin-insights:fetch-products
     */30 * * * * pimee:franklin-insights:fetch-products --env=prod
+    #Ansible: pimee:franklin-insights:quality-highlights:push-structure-and-products
+    15 */12 * * * * pimee:franklin-insights:quality-highlights:push-structure-and-products --env=prod
     #Ansible: akeneo:reference-entity:refresh-records --all
     0 23 * * * akeneo:reference-entity:refresh-records --all --env=prod
 
@@ -116,16 +118,18 @@ The default crontab at the moment on our Flexibility environments is the followi
 
 Enterprise Edition specific crontab:
 
-+----------------------------------------------------------+-------------------+-------------------------------------------+
-| Symfony console command                                  | Crontab frequency | Human frequency                           |
-+==========================================================+===================+===========================================+
-| akeneo:rule:run --env=prod                               | 0 5 \* \* \*      | At 05:00 AM                               |
-+----------------------------------------------------------+-------------------+-------------------------------------------+
-| pimee:project:notify-before-due-date --env=prod          | 20 0 \* \* \*     | At 12:20 AM                               |
-+----------------------------------------------------------+-------------------+-------------------------------------------+
-| pimee:project:recalculate --env=prod                     | 0 2 \* \* \*      | At 02:00 AM                               |
-+----------------------------------------------------------+-------------------+-------------------------------------------+
-| pimee:franklin-insights:fetch-products --env=prod        | \*/30 \* \* \* \* | Every 30 minutes                          |
-+----------------------------------------------------------+-------------------+-------------------------------------------+
-| akeneo:reference-entity:refresh-records --all --env=prod | 0 23 \* \* \*     | At 11:00 PM                               |
-+----------------------------------------------------------+-------------------+-------------------------------------------+
++-----------------------------------------------------------------------------------+----------------------+-------------------------------------------+
+| Symfony console command                                                           | Crontab frequency    | Human frequency                           |
++===================================================================================+======================+===========================================+
+| akeneo:rule:run --env=prod                                                        | 0 5 \* \* \*         | At 05:00 AM                               |
++-----------------------------------------------------------------------------------+----------------------+-------------------------------------------+
+| pimee:project:notify-before-due-date --env=prod                                   | 20 0 \* \* \*        | At 12:20 AM                               |
++-----------------------------------------------------------------------------------+----------------------+-------------------------------------------+
+| pimee:project:recalculate --env=prod                                              | 0 2 \* \* \*         | At 02:00 AM                               |
++-----------------------------------------------------------------------------------+----------------------+-------------------------------------------+
+| pimee:franklin-insights:fetch-products --env=prod                                 | \*/30 \* \* \* \*    | Every 30 minutes                          |
++-----------------------------------------------------------------------------------+----------------------+-------------------------------------------+
+| pimee:franklin-insights:quality-highlights:push-structure-and-products --env=prod | 15 \*/12 \* \* \* \* | Every 12 hours past 15 minutes            |
++-----------------------------------------------------------------------------------+----------------------+-------------------------------------------+
+| akeneo:reference-entity:refresh-records --all --env=prod                          | 0 23 \* \* \*        | At 11:00 PM                               |
++-----------------------------------------------------------------------------------+----------------------+-------------------------------------------+

--- a/install_pim/manual/crontab_tasks_ee.rst.inc
+++ b/install_pim/manual/crontab_tasks_ee.rst.inc
@@ -9,21 +9,35 @@ Edit your crontab with ``crontab -e`` and configure your tasks.
 
     Be sure to update the cron of the user used to install the PIM, to be able to run the command
 
-You have to add these 6 commands to your local installation:
+You have to add the following commands to your local installation:
 
 .. code-block:: bash
     :linenos:
 
-    php /path/to/installation/pim-enterprise-standard/bin/console pim:completeness:calculate --env=prod                                 # recalculates the products completeness
-    php /path/to/installation/pim-enterprise-standard/bin/console pim:versioning:refresh --env=prod                                     # processes pending versions
-    php /path/to/installation/pim-enterprise-standard/bin/console akeneo:rule:run --env=prod                                            # executes rules on products
-    php /path/to/installation/pim-enterprise-standard/bin/console pimee:project:notify-before-due-date --env=prod                       # check and send notifications (TeamWork Assistant)
-    php /path/to/installation/pim-enterprise-standard/bin/console pim:asset:send-expiration-notification --env=prod                     # check and send notifications for asset date delay
-    php /path/to/installation/pim-enterprise-standard/bin/console pimee:project:recalculate --env=prod                                  # recalculate project completeness (TeamWork Assistant)
-    php /path/to/installation/pim-enterprise-standard/bin/console pimee:franklin-insights:fetch-products --env=prod # fetch suggested data for products subscribed to Franklin Insights
+    # PIM native commands
+
+    # recalculates the products completeness
+    php /path/to/installation/pim-enterprise-standard/bin/console pim:completeness:calculate --env=prod
+    # processes pending versions
+    php /path/to/installation/pim-enterprise-standard/bin/console pim:versioning:refresh --env=prod
+    # executes rules on products
+    php /path/to/installation/pim-enterprise-standard/bin/console akeneo:rule:run --env=prod
+    # check and send notifications (TeamWork Assistant)
+    php /path/to/installation/pim-enterprise-standard/bin/console pimee:project:notify-before-due-date --env=prod
+    # check and send notifications for asset date delay
+    php /path/to/installation/pim-enterprise-standard/bin/console pim:asset:send-expiration-notification --env=prod
+    # recalculate project completeness (TeamWork Assistant)
+    php /path/to/installation/pim-enterprise-standard/bin/console pimee:project:recalculate --env=prod
+
+    # Franklin Insights specific commands
+
+    # fetch suggested data for products subscribed to Franklin Insights
+    php /path/to/installation/pim-enterprise-standard/bin/console pimee:franklin-insights:fetch-products --env=prod
+    # push structure and products data in order to compute the Quality Highlights metrics
+    php /path/to/installation/pim-enterprise-standard/bin/console pimee:franklin-insights:quality-highlights:push-structure-and-products --env=prod
 
 .. note::
-   **Note:** The command ``pimee:franklin-insights:fetch-products`` is to be set only if you activate Franklin Insights EE feature.
+   **Note:** The commands ``pimee:franklin-insights:*`` have to be set only if you activate Franklin Insights EE feature.
 
 
 In the following example, these lines will run the completeness calculation at 11pm, the versioning calculation at 5am, the rules calculation at 6pm and the aggregate volume at 10pm every day:


### PR DESCRIPTION
… EE installation documentation

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/3.0/.github/CONTRIBUTING.md) --->

**Description**

:warning: Do not merge this before Quality Highlights code base is tagged and released.

In the PIM EE installation procedure we add a new `franklin-insights` symfony command to be configured into the CRONTAB

Before:
![before](https://user-images.githubusercontent.com/927944/64341867-983d6200-cfe9-11e9-9655-b21ad9fd4af0.png)

After:
![after](https://user-images.githubusercontent.com/927944/64341874-9bd0e900-cfe9-11e9-859b-2ae8fcb57a6c.png)

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
