### PR TITLE
Add instructions on how to enable/disable job configurations

### DIFF
--- a/cloud_edition/flexibility_mode/docs/partners.rst
+++ b/cloud_edition/flexibility_mode/docs/partners.rst
@@ -50,6 +50,9 @@ Create a new daemon by enabling and then starting a service with a **unique** id
     # Check the status of the daemon
     partners_systemctl pim_job_queue@1 status
 
+    # Stop the daemon
+    partners_systemctl pim_job_queue@1 stop
+
     # See real time logs for daemon #2
     journalctl --unit=pim_job_queue@2 -f
 

--- a/cloud_edition/flexibility_mode/docs/partners.rst
+++ b/cloud_edition/flexibility_mode/docs/partners.rst
@@ -30,10 +30,16 @@ This daemon is managed by ``systemd`` and allows multiple operations such as:
 Please note that, while the number of running job consumers is not enforced, it is not recommended
 to increase it above the server capability. Between 1 and 3 comsumers is recommended.
 
-Create a new daemon by starting a service with a **unique** identifier:
+Create a new daemon by enabling and then starting a service with a **unique** identifier:
 
 .. code-block:: bash
     :linenos:
+
+    # Enable the daemon #1
+    partners_systemctl pim_job_queue@1 enable
+
+    # Enable the daemon #2
+    partners_systemctl pim_job_queue@2 enable
 
     # Launch the daemon #1
     partners_systemctl pim_job_queue@1 start
@@ -43,9 +49,6 @@ Create a new daemon by starting a service with a **unique** identifier:
 
     # Check the status of the daemon
     partners_systemctl pim_job_queue@1 status
-
-    # Stop the daemon
-    partners_systemctl pim_job_queue@1 stop
 
     # See real time logs for daemon #2
     journalctl --unit=pim_job_queue@2 -f
@@ -59,5 +62,14 @@ Useful commands
     # check the status of all running queues
     partners_systemctl pim_job_queue@* status
 
+    # restart all enabled daemons
+    # Note: disabled or manually started daemons will not be restarted
+    #       for this reason, always enable/disable daemons as you need them.
+    partners_systemctl pim_job_queue@* status
+
     # see logs for job consumer "foo", append with "-f" for real time display.
     journalctl --unit=pim_job_queue@2 -f
+
+    # Disable a daemon
+    partners_systemctl pim_job_queue@2 disable
+


### PR DESCRIPTION
**Description**

This adds instructions on how to enable disable job configurations for job consumers on Flex instances.
**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | :heavy_check_mark: 
| English Review and 1 GTM          | :heavy_check_mark: 

**Note**: Applies to 2.x and 3.x, all versions included.