### PR TITLE
Update creating_a_reference_data.rst

### DIFF
--- a/manipulate_pim_data/catalog_structure/creating_a_reference_data.rst
+++ b/manipulate_pim_data/catalog_structure/creating_a_reference_data.rst
@@ -195,20 +195,22 @@ For a simple reference data:
 .. code-block:: yaml
 
     # /app/config/config.yml
-    pim_reference_data:
-        color:
-            class: Acme\Bundle\AppBundle\Entity\Color
-            type: simple
+    akeneo_pim_structure:
+        reference_data:
+            color:
+                class: Acme\Bundle\AppBundle\Entity\Color
+                type: simple
 
 For a multiple reference data:
 
 .. code-block:: yaml
 
     # /app/config/config.yml
-    pim_reference_data:
-        colors:
-            class: Acme\Bundle\AppBundle\Entity\Color
-            type: multi
+    akeneo_pim_structure:
+        reference_data:
+            colors:
+                class: Acme\Bundle\AppBundle\Entity\Color
+                type: multi
 
 The reference data name (here `color` or `colors`) must use only letters and be camel-cased: the same `Color`
 entity can be used as simple or multiple reference data.


### PR DESCRIPTION
The previous pim_reference_data configuration is incorrect for version 3.2.

**Description**

In Akeneo 3.2, pim_reference_data is no longer used. You need to add custom entities below the akeneo_pim_structure -> reference_data configuration.


