### PR TITLE
PIM-8907: fix width of guides drop down menu

### DIFF
--- a/_themes/akeneo/layout.html
+++ b/_themes/akeneo/layout.html
@@ -53,6 +53,7 @@
         nav { transition: box-shadow 0.2s ease-in-out; }
         .nav .dropdown:first-child { float: right; }
         .nav .dropdown:nth-child(2) .dropdown-menu { left: -175px; }
+        .nav .dropdown:nth-child(3) .dropdown-menu { left: -200px; }
         .algolia-docsearch-suggestion--category-header { background-color: white; }
         .table { overflow: auto; display: block; width: 100%; }
         table.table tbody { display: table; width: 100%; }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

Links of the *Guides* drop-down menu extended beyond the menu shading. The width was not large enough.  

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed


Before:

![doc-before](https://user-images.githubusercontent.com/4737390/67846908-3fc6a480-fb02-11e9-93c9-b5d27af8096e.png)

After:

![image](https://user-images.githubusercontent.com/4737390/67861831-3f89d180-fb21-11e9-914e-633a1a02053c.png)

