### PR TITLE
fixed wrong lines in import_and_export/guides/create-connector.rst

### DIFF
--- a/import_and_export_data/guides/create-connector.rst
+++ b/import_and_export_data/guides/create-connector.rst
@@ -24,7 +24,7 @@ Jobs and steps are actually Symfony services. The first thing we need is to decl
 .. literalinclude:: ../../src/Acme/Bundle/NotifyConnectorBundle/Resources/config/jobs.yml
     :language: yaml
     :linenos:
-    :lines: 1-12,14-
+    :lines: 1-13,15-
 
 .. warning::
 


### PR DESCRIPTION
**Description**

There is a mistake in configuration (highlighted).
![Screenshot from 2019-11-26 15-03-06](https://user-images.githubusercontent.com/16201014/69610266-05e3b200-105e-11ea-984c-84262bcde01d.png)

It should be `@pim_connector.step.csv_product.export`

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
