### PR TITLE
Fix 3.2 documentation CI due to wrong link

### DIFF
--- a/contribute_to_pim/documentation.rst
+++ b/contribute_to_pim/documentation.rst
@@ -176,6 +176,6 @@ You can also add links to the PHP documentation:
 .. _documents:               https://github.com/akeneo/pim-docs
 .. _reStructuredText Primer: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
 .. _markup:                  https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html
-.. _Pygments website:        https://pygments.org/languages.html
+.. _Pygments website:        https://pygments.org/languages/
 .. _source:                  https://github.com/fabpot/sphinx-php
 .. _Sphinx quick setup:      https://www.sphinx-doc.org/en/master/usage/quickstart.html#setting-up-the-documentation-sources


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
