### PR TITLE
DAPI 691 - Add to the pim documentation how to blacklist some jobs in…

### DIFF
--- a/install_pim/manual/daemon_queue.rst
+++ b/install_pim/manual/daemon_queue.rst
@@ -39,6 +39,15 @@ Here is an example with a few bulk actions:
 
     $ /path/to/php /path/to/your/pim/bin/console akeneo:batch:job-queue-consumer-daemon --env=prod -j update_product_value -j add_product_value -j remove_product_value
 
+You can also exclude some jobs from a consumer (blacklisted jobs). This could be useful if you want a specific job to be consumed by another consumer.
+Here is an example with a few bulk actions:
+
+
+.. code-block:: bash
+    :linenos:
+
+    $ /path/to/php /path/to/your/pim/bin/console akeneo:batch:job-queue-consumer-daemon --env=prod -b update_product_value -b add_product_value -b remove_product_value
+
 Logs
 ----
 


### PR DESCRIPTION
… the execution queue

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

Pull request of the DAPI-691 - Add a blacklist option to the CE job queue daemon command => https://github.com/akeneo/pim-community-dev/pull/11194#pullrequestreview-328798952

**Description**
The goal is to add to the pim documentation the process to blacklist some of the jobs of the execution queue.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
