### PR TITLE
Remove unused extension sensio.sphinx.refinclude

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -31,7 +31,7 @@ from pygments.lexers.shell import BashLexer
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sensio.sphinx.refinclude', 'sensio.sphinx.configurationblock', 'sensio.sphinx.phpcode' , 'sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.ifconfig', 'sphinxcontrib.youtube']
+extensions = ['sensio.sphinx.configurationblock', 'sensio.sphinx.phpcode' , 'sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.ifconfig', 'sphinxcontrib.youtube']
 lexers['php'] = PhpLexer(startinline=True)
 lexers['php-annotations'] = PhpLexer(startinline=True)
 lexers['html'] = HtmlLexer()


### PR DESCRIPTION
The extension `sensio.sphinx.configurationblock` has been removed recently: https://github.com/fabpot/sphinx-php/commit/990a07169de569f058492f9f6b2fca6e25bbabd5
Keep it makes the build CI fail