### PR TITLE
AOB-880: Fix copy path in Onboarder install doc

### DIFF
--- a/onboarder/installation/index.rst
+++ b/onboarder/installation/index.rst
@@ -41,7 +41,7 @@ Copy the extension configuration in the ``config`` directory
 
 .. code-block:: bash
 
-    cp vendor/akeneo/pim-onboarder/src/Bundle/Resources/config/onboarder_configuration.yml config/onboarder_configuration.yml
+    cp vendor/akeneo/pim-onboarder/src/Bundle/Resources/config/onboarder_configuration.yml config/packages/onboarder.yml
 
 Make the credential files accessible to Akeneo PIM software
 -----------------------------------------------------------


### PR DESCRIPTION
**Description**

The Onboarder YAML configuration file was not copied in the right PIM directory

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
