### PR TITLE
Fix deployments through CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,42 @@
-version: 2
+version: 2.1
+
+commands:
+    configure-composer-auth:
+        description: Configure composer auth
+        steps:
+            - run: mkdir -p ~/.composer/cache
+            - run:
+                name: Add GitHub token for composer
+                command: echo ${COMPOSER_AUTH} > ~/.composer/auth.json
+
+    restore-composer-cache:
+        description: Restore Composer cache
+        steps:
+            - restore_cache:
+                name: Restore Composer cache
+                keys:
+                    - composer-{{ .Branch }}
+                    - composer-
+
+    save-composer-cache:
+        description: Save Composer cache
+        steps:
+            - save_cache:
+                name: Save Composer cache
+                key: composer-{{ .Branch }}
+                paths:
+                    - ~/.composer/cache
+
 jobs:
     build:
         machine:
-            image: ubuntu-1604:201903-01
+            image: ubuntu-1604:202004-01
         steps:
             - checkout
+            - configure-composer-auth
+            - restore-composer-cache
             - run: make build
+            - save-composer-cache
 
     deploy_staging:
         machine:
@@ -14,9 +45,12 @@ jobs:
             - checkout
             - add_ssh_keys
             - run: sudo chown 1000:1000 $SSH_AUTH_SOCK
+            - configure-composer-auth
+            - restore-composer-cache
             - run:
                   name: Deploy on staging server
                   command: DEPLOY_HOSTNAME=$STAGING_HOSTNAME DEPLOY_PORT=$STAGING_PORT VERSION="4.0" make deploy
+            - save-composer-cache
 
     deploy_production:
         machine:
@@ -25,9 +59,13 @@ jobs:
             - checkout
             - add_ssh_keys
             - run: sudo chown 1000:1000 $SSH_AUTH_SOCK
+            - configure-composer-auth
+            - restore-composer-cache
             - run:
                   name: Deploy on production server
                   command: DEPLOY_HOSTNAME=$PROD_HOSTNAME DEPLOY_PORT=$PROD_PORT VERSION="4.0" make deploy
+            - save-composer-cache
+
 workflows:
     version: 2
     pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/design_pim/
 /pim-docs-build/
 /pim-docs-lint/
 /docker-compose.override.yml

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ UID = $(shell id -u)
 GID = $(shell id -g)
 DOCKER_IMAGE = pim-docs
 DOCKER_RUN = docker run -it --rm -v $(PWD):/home/akeneo/pim-docs/
-DOCKER_RUN_WITH_CIRCLE_IDS = ${DOCKER_RUN} -u $(UID):$(GID)
+DOCKER_RUN_WITH_CIRCLE_IDS = ${DOCKER_RUN} -u $(UID):$(GID) -v ~/.composer:/.composer
 
 .DEFAULT_GOAL := build
 .PHONY: build, deploy, docker-build
@@ -29,11 +29,11 @@ docker-build:
 	docker build . --tag $(DOCKER_IMAGE)
 
 check-uses: docker-build
-	${DOCKER_RUN_WITH_CIRCLE_IDS} -e COMPOSER_AUTH -v ~/.composer:/home/akeneo/.composer ${DOCKER_IMAGE} /home/akeneo/pim-docs/scripts/test_php_uses.sh
+	${DOCKER_RUN_WITH_CIRCLE_IDS} ${DOCKER_IMAGE} /home/akeneo/pim-docs/scripts/test_php_uses.sh
 
 styleguide: docker-build
 	$(DOCKER_RUN_WITH_CIRCLE_IDS) -w /home/akeneo/pim-docs/design_pim/styleguide $(DOCKER_IMAGE) cp styleguide.js /home/akeneo/pim-docs/pim-docs-build/design_pim/styleguide/
 	$(DOCKER_RUN_WITH_CIRCLE_IDS) -w /home/akeneo/pim-docs/design_pim/styleguide $(DOCKER_IMAGE) cp styleguide.css /home/akeneo/pim-docs/pim-docs-build/design_pim/styleguide/
 	$(DOCKER_RUN_WITH_CIRCLE_IDS) -w /home/akeneo/pim-docs/design_pim/styleguide $(DOCKER_IMAGE) ./prepare_static_files.sh
-	$(DOCKER_RUN_WITH_CIRCLE_IDS) -w /home/akeneo/pim-docs/design_pim/styleguide $(DOCKER_IMAGE) php /usr/local/bin/composer.phar install
+	$(DOCKER_RUN_WITH_CIRCLE_IDS) -w /home/akeneo/pim-docs/design_pim/styleguide $(DOCKER_IMAGE) php /usr/local/bin/composer.phar install --no-plugins
 	$(DOCKER_RUN_WITH_CIRCLE_IDS) -w /home/akeneo/pim-docs/design_pim/styleguide $(DOCKER_IMAGE) bash -c "php index.php > /home/akeneo/pim-docs/pim-docs-build/design_pim/styleguide/index.html"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 UID = $(shell id -u)
 GID = $(shell id -g)
 DOCKER_IMAGE = pim-docs
-DOCKER_RUN = docker run -it --rm -u $(UID):$(GID) -v $(PWD):/home/akeneo/pim-docs/
+DOCKER_RUN = docker run -it --rm -v $(PWD):/home/akeneo/pim-docs/
+DOCKER_RUN_WITH_CIRCLE_IDS = ${DOCKER_RUN} -u $(UID):$(GID)
 
 .DEFAULT_GOAL := build
 .PHONY: build, deploy, docker-build
@@ -16,23 +17,23 @@ build: clean check-uses lint html styleguide
 	@echo "\nYou are now ready to check the documentation locally in the directory \"pim-docs-build/\" and to deploy it with \"DEPLOY_HOSTNAME=foo.com DEPLOY_PORT=1985 VERSION=bar make deploy\"."
 
 deploy: build
-	$(DOCKER_RUN) -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE) rsync -e "ssh -q -p $${DEPLOY_PORT} -o StrictHostKeyChecking=no" -qarz --delete /home/akeneo/pim-docs/pim-docs-build/ akeneo@$${DEPLOY_HOSTNAME}:/var/www/${VERSION}
+	$(DOCKER_RUN) -u 1000:1000 -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE) rsync -e "ssh -q -p $${DEPLOY_PORT} -o StrictHostKeyChecking=no" -qarz --delete /home/akeneo/pim-docs/pim-docs-build/ akeneo@$${DEPLOY_HOSTNAME}:/var/www/${VERSION}
 
 lint: docker-build
-	$(DOCKER_RUN) $(DOCKER_IMAGE) sphinx-build -nWT -b linkcheck /home/akeneo/pim-docs/ /home/akeneo/pim-docs/pim-docs-lint
+	$(DOCKER_RUN_WITH_CIRCLE_IDS) $(DOCKER_IMAGE) sphinx-build -nWT -b linkcheck /home/akeneo/pim-docs/ /home/akeneo/pim-docs/pim-docs-lint
 
 html: docker-build
-	$(DOCKER_RUN) $(DOCKER_IMAGE) sphinx-build -b html /home/akeneo/pim-docs/ /home/akeneo/pim-docs/pim-docs-build
+	$(DOCKER_RUN_WITH_CIRCLE_IDS) $(DOCKER_IMAGE) sphinx-build -b html /home/akeneo/pim-docs/ /home/akeneo/pim-docs/pim-docs-build
 
 docker-build:
 	docker build . --tag $(DOCKER_IMAGE)
 
 check-uses: docker-build
-	${DOCKER_RUN} -e COMPOSER_AUTH -v ~/.composer:/home/akeneo/.composer ${DOCKER_IMAGE} /home/akeneo/pim-docs/scripts/test_php_uses.sh
+	${DOCKER_RUN_WITH_CIRCLE_IDS} -e COMPOSER_AUTH -v ~/.composer:/home/akeneo/.composer ${DOCKER_IMAGE} /home/akeneo/pim-docs/scripts/test_php_uses.sh
 
 styleguide: docker-build
-	$(DOCKER_RUN) -w /home/akeneo/pim-docs/design_pim/styleguide $(DOCKER_IMAGE) cp styleguide.js /home/akeneo/pim-docs/pim-docs-build/design_pim/styleguide/
-	$(DOCKER_RUN) -w /home/akeneo/pim-docs/design_pim/styleguide $(DOCKER_IMAGE) cp styleguide.css /home/akeneo/pim-docs/pim-docs-build/design_pim/styleguide/
-	$(DOCKER_RUN) -w /home/akeneo/pim-docs/design_pim/styleguide $(DOCKER_IMAGE) ./prepare_static_files.sh
-	$(DOCKER_RUN) -w /home/akeneo/pim-docs/design_pim/styleguide $(DOCKER_IMAGE) php /usr/local/bin/composer.phar install
-	$(DOCKER_RUN) -w /home/akeneo/pim-docs/design_pim/styleguide $(DOCKER_IMAGE) bash -c "php index.php > /home/akeneo/pim-docs/pim-docs-build/design_pim/styleguide/index.html"
+	$(DOCKER_RUN_WITH_CIRCLE_IDS) -w /home/akeneo/pim-docs/design_pim/styleguide $(DOCKER_IMAGE) cp styleguide.js /home/akeneo/pim-docs/pim-docs-build/design_pim/styleguide/
+	$(DOCKER_RUN_WITH_CIRCLE_IDS) -w /home/akeneo/pim-docs/design_pim/styleguide $(DOCKER_IMAGE) cp styleguide.css /home/akeneo/pim-docs/pim-docs-build/design_pim/styleguide/
+	$(DOCKER_RUN_WITH_CIRCLE_IDS) -w /home/akeneo/pim-docs/design_pim/styleguide $(DOCKER_IMAGE) ./prepare_static_files.sh
+	$(DOCKER_RUN_WITH_CIRCLE_IDS) -w /home/akeneo/pim-docs/design_pim/styleguide $(DOCKER_IMAGE) php /usr/local/bin/composer.phar install
+	$(DOCKER_RUN_WITH_CIRCLE_IDS) -w /home/akeneo/pim-docs/design_pim/styleguide $(DOCKER_IMAGE) bash -c "php index.php > /home/akeneo/pim-docs/pim-docs-build/design_pim/styleguide/index.html"

--- a/scripts/test_php_uses.sh
+++ b/scripts/test_php_uses.sh
@@ -25,5 +25,5 @@ cp $SCRIPT_DIR/check_uses_existence.php $EE_STD_DIR/
 
 cd $EE_STD_DIR
 
-php -d memory_limit=4G /usr/local/bin/composer.phar install
+php -d memory_limit=4G /usr/local/bin/composer.phar install --no-plugins
 php check_uses_existence.php php_uses.list


### PR DESCRIPTION
**Description**

The CI couldn't deploy the documentation on staging for a month. Issue were with the permissions inside the container. As the `SSH_AUTH_SOCK` is set to `1000:1000`, so we need to run rsync with the same IDs, not with CircleCI IDs which are `1001:1002`.

As I couldn't have a green CI because of the GitHub API rate limit with composer, I also fixed the use of `COMPOSER_AUTH` and added composer cache on the CI.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | OK
| English Review and 1 GTM          | -


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
