### PR TITLE
Revert the adding of composer cache on 4.0 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,4 @@
-version: 2.1
-
-commands:
-    configure-composer-auth:
-        description: Configure composer auth
-        steps:
-            - run: mkdir -p ~/.composer/cache
-            - run:
-                name: Add GitHub token for composer
-                command: echo ${COMPOSER_AUTH} > ~/.composer/auth.json
-
-    restore-composer-cache:
-        description: Restore Composer cache
-        steps:
-            - restore_cache:
-                name: Restore Composer cache
-                keys:
-                    - composer-{{ .Branch }}
-                    - composer-
-
-    save-composer-cache:
-        description: Save Composer cache
-        steps:
-            - save_cache:
-                name: Save Composer cache
-                key: composer-{{ .Branch }}
-                paths:
-                    - ~/.composer/cache
+version: 2.0
 
 jobs:
     build:
@@ -33,38 +6,27 @@ jobs:
             image: ubuntu-1604:202004-01
         steps:
             - checkout
-            - configure-composer-auth
-            - restore-composer-cache
             - run: make build
-            - save-composer-cache
 
     deploy_staging:
         machine:
-            image: ubuntu-1604:201903-01
+            image: ubuntu-1604:202004-01
         steps:
             - checkout
             - add_ssh_keys
-            - run: sudo chown 1000:1000 $SSH_AUTH_SOCK
-            - configure-composer-auth
-            - restore-composer-cache
             - run:
                   name: Deploy on staging server
                   command: DEPLOY_HOSTNAME=$STAGING_HOSTNAME DEPLOY_PORT=$STAGING_PORT VERSION="4.0" make deploy
-            - save-composer-cache
 
     deploy_production:
         machine:
-            image: ubuntu-1604:201903-01
+            image: ubuntu-1604:202004-01
         steps:
             - checkout
             - add_ssh_keys
-            - run: sudo chown 1000:1000 $SSH_AUTH_SOCK
-            - configure-composer-auth
-            - restore-composer-cache
             - run:
                   name: Deploy on production server
                   command: DEPLOY_HOSTNAME=$PROD_HOSTNAME DEPLOY_PORT=$PROD_PORT VERSION="4.0" make deploy
-            - save-composer-cache
 
 workflows:
     version: 2


### PR DESCRIPTION
**Description**

This PR removes the recent [adding of composer cache](https://github.com/akeneo/pim-docs/pull/1465) on Circle CI.

Removing the usage of `chown 1000:1000` on the SSH keys should be enough to definitively fix what the previous PR tried to fix.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | -


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
