### PR TITLE
Fix JQuery version on System Requirements in 4.0

### DIFF
--- a/install_pim/manual/system_requirements/system_requirements.rst.inc
+++ b/install_pim/manual/system_requirements/system_requirements.rst.inc
@@ -101,6 +101,8 @@ Besides these modules, the following configuration is the minimal configuration 
 +----------------+---------------------------+
 | yarn           | ≥ 1.0.0                   |
 +----------------+---------------------------+
+| JQuery         | 3.4                       |
++----------------+---------------------------+
 
 .. _database-servers:
 


### PR DESCRIPTION
If you remove the yarn.lock and executes a `yarn install` it will install the version 3.5 of JQuery. 
But the PIM is not compatible now with this version (it's not compatible with our Datagrid).

We need to specify it in our System Requirements
