### PR TITLE
fix broken link, latest doctrine migration link do not work anymore

### DIFF
--- a/contribute_to_pim/contribution_guide.rst
+++ b/contribute_to_pim/contribution_guide.rst
@@ -399,7 +399,7 @@ messages of all the commits. When you are finished, execute the push command.
 .. _`behat quick intro`:                https://docs.behat.org/en/latest/quick_start.html
 .. _`begin with PHPSpec`:               https://www.phpspec.net/
 .. _`Prophecy documentation`:           https://github.com/phpspec/prophecy#prophecy
-.. _`Doctrine migration documentation`: https://www.doctrine-project.org/projects/doctrine-migrations/en/latest/reference/introduction.html
+.. _`Doctrine migration documentation`: https://www.doctrine-project.org/projects/doctrine-migrations/en/1.8/reference/introduction.html
 
 Step 4: Is my pull request merged?
 ----------------------------------


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

There is no "latest" link to access doctrine migration documentation, I update the link to target the 1.8 version which is the one used in composer dependencies.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
