### PR TITLE
Revert "RUL-346: update completeness operators"

### DIFF
--- a/manipulate_pim_data/rule/general_information_on_rule_format.rst
+++ b/manipulate_pim_data/rule/general_information_on_rule_format.rst
@@ -762,31 +762,25 @@ _______
 
 Completeness
 ____________
-+--------------+---------------------------------------------------------------------------+
-| Operator     | - EQUALS ON AT LEAST ONE LOCALE                                           |
-|              | - NOT EQUALS ON AT LEAST ONE LOCALE                                       |
-|              | - GREATER THAN ON AT LEAST ONE LOCALE                                     |
-|              | - GREATER OR EQUALS THAN ON AT LEAST ONE LOCALE                           |
-|              | - LOWER THAN ON AT LEAST ONE LOCALE                                       |
-|              | - LOWER OR EQUALS THAN ON AT LEAST ONE LOCALE                             |
-|              | - =   (deprecated please use EQUALS ON AT LEAST ONE LOCALE instead)       |
-|              | - !=  (deprecated please use NOT EQUALS ON AT LEAST ONE LOCALE instead)   |
-|              | - ">" (deprecated please use GREATER THAN ON AT LEAST ONE LOCALE instead) |
-|              | - <   (deprecated please use LOWER THAN ON AT LEAST ONE LOCALE instead)   |
-+--------------+---------------------------------------------------------------------------+
-| Value        | Percentage.                                                               |
-|              | /!\\ locale and scope                                                     |
-|              | elements are                                                              |
-|              | mandatory.                                                                |
-+--------------+---------------------------------------------------------------------------+
-| Example      | .. code-block:: yaml                                                      |
-|              |                                                                           |
-|              |   field: completeness                                                     |
-|              |   locale: fr_FR                                                           |
-|              |   scope: print                                                            |
-|              |   operator: EQUALS ON AT LEAST ONE LOCALE                                 |
-|              |   value: "100"                                                            |
-+--------------+---------------------------------------------------------------------------+
++--------------+-----------------------+
+| Operator     | - =                   |
+|              | - !=                  |
+|              | - ">"                 |
+|              | - <                   |
++--------------+-----------------------+
+| Value        | Percentage.           |
+|              | /!\\ locale and scope |
+|              | elements are          |
+|              | mandatory.            |
++--------------+-----------------------+
+| Example      | .. code-block:: yaml  |
+|              |                       |
+|              |   field: completeness |
+|              |   locale: fr_FR       |
+|              |   scope: print        |
+|              |   operator: =         |
+|              |   value: "100"        |
++--------------+-----------------------+
 
 Family
 ______


### PR DESCRIPTION
This reverts commit 0288c9a822820f4b21e5d70f80337c8e78281f03.

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
