### PR TITLE
Update system_install_ubuntu_1804.rst

### DIFF
--- a/install_pim/manual/system_requirements/system_install_ubuntu_1804.rst
+++ b/install_pim/manual/system_requirements/system_install_ubuntu_1804.rst
@@ -73,9 +73,8 @@ The easiest way to install Elasticsearch 7 is to use the `official vendor packag
 .. code-block:: bash
 
     # apt-get install apt-transport-https
-    # wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
-    # echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list
-    # apt update && apt-get install elasticsearch
+    # wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.5.2-amd64.deb
+    # dpkg -i elasticsearch-7.5.2-amd64.deb
     # service elasticsearch start
 
 .. warning::


### PR DESCRIPTION
The guide for installing Elasticsearch 7.5 will actually install 7.8.x which is not compatible with Akeneo 4.x one issue is that bulk action is not working. To install 7.5.x you need to manually install the package from elastic. Even better if Akeneo was updated to support the latest version of ES.

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
