### PR TITLE
PIM-9384: Fix install assets command

### DIFF
--- a/design_pim/guides/add_new_page.rst
+++ b/design_pim/guides/add_new_page.rst
@@ -93,9 +93,7 @@ To view your changes, you have to dump new routes and rebuild assets:
 
 .. code-block:: bash
 
-    $ bin/console pim:installer:dump-require-paths
-    $ bin/console pim:install:assets
-    $ bin/console assets:install --symlink
+    $ bin/console --env=prod pim:installer:assets --symlink --clean
     $ yarn run less
     $ yarn run webpack
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

The command to install assets was outdated for `4.0`

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | -


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
