### PR TITLE
PIM-9422: Make the menu customization doc clearer

### DIFF
--- a/design_pim/guides/how_to_customize_menu.rst
+++ b/design_pim/guides/how_to_customize_menu.rst
@@ -36,9 +36,8 @@ Now if you want to add an element inside the menu, you can use the item module:
         acme-custom-sub-element:                           # The unique key of your extension
             module: pim/menu/item                          # The module provided by akeneo for sub elements
             parent: acme-custom-root-element               # The parent is the tab we just created
-            targetZone: item
             # aclResourceId: my_custom_acl_key             # [optional] You can define a acl check - add this only if the acl has been created
-            position: 110                                  # [optional] The position in the tree where you want to add the item
+            position: 120                                  # [optional] The position in the tree where you want to add the item
             config:
                 title: pim_menu.item.import_profile        # You can define a translation key for the item name
                 to: pim_importexport_import_profile_index  # The route to redirect to

--- a/design_pim/guides/how_to_customize_menu.rst
+++ b/design_pim/guides/how_to_customize_menu.rst
@@ -16,13 +16,13 @@ To add an element at the root of the tree you can reuse the tab module provided 
             module: pim/menu/tab                           # The module provided by akeneo for root elements
             parent: pim-menu                               # The parent is the root of the menu
             targetZone: mainMenu
-            aclResourceId: my_custom_acl_key               # [optional] You can define a acl check - remove if this acl has not been created yet
+            # aclResourceId: my_custom_acl_key             # [optional] You can define a acl check - add this only if the acl has been created
             position: 110                                  # [optional] The position in the tree where you want to add the item
             config:
                 title: pim_menu.item.import_profile        # You can define a translation key for the tab name
                 to: pim_importexport_import_profile_index  # The route to redirect to
 
-After running the command ``rm -rf var/cache; bin/console pim:install:asset; yarn run webpack`` your new item should appear at the root of the menu.
+After running the command ``rm -rf var/cache; bin/console pim:installer:assets; yarn run webpack`` your new item should appear at the root of the menu.
 
 Define a simple node inside a tab of the menu
 *********************************************
@@ -37,13 +37,13 @@ Now if you want to add an element inside the menu, you can use the item module:
             module: pim/menu/item                          # The module provided by akeneo for sub elements
             parent: acme-custom-root-element               # The parent is the tab we just created
             targetZone: item
-            aclResourceId: my_custom_acl_key               # [optional] You can define a acl check - remove if this acl has not been created yet
+            # aclResourceId: my_custom_acl_key             # [optional] You can define a acl check - add this only if the acl has been created
             position: 110                                  # [optional] The position in the tree where you want to add the item
             config:
                 title: pim_menu.item.import_profile        # You can define a translation key for the item name
                 to: pim_importexport_import_profile_index  # The route to redirect to
 
-After running the command ``rm -rf var/cache; bin/console pim:install:asset; yarn run webpack`` your new item should appear in the menu.
+After running the command ``rm -rf var/cache; bin/console pim:installer:assets; yarn run webpack`` your new item should appear in the menu.
 
 Highlight menu elements
 ***********************
@@ -66,7 +66,7 @@ This module will both display the breadcrumbs and highlight the menu. You simply
                 tab: acme-custom-root-element
                 item: acme-custom-sub-element
 
-After running the command ``rm -rf var/cache; bin/console pim:install:asset; yarn run webpack`` the menu will be highlited when you will open your custom page.
+After running the command ``rm -rf var/cache; bin/console pim:installer:assets; yarn run webpack`` the menu will be highlited when you will open your custom page.
 
 Use you own menu extension item
 *******************************


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

- Comment the ACL line by default because the menu entry won't be displayed if the ACL does not exist yet.
- Update the assets install command

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
