### PR TITLE
Update apply_patch_ee_flexibility.rst

### DIFF
--- a/migrate_pim/apply_patch/apply_patch_ee_flexibility.rst
+++ b/migrate_pim/apply_patch/apply_patch_ee_flexibility.rst
@@ -19,6 +19,12 @@ To upgrade, please change the composer.json to:
         ...
     }
 
+You can use a text editor (vi) or the composer require command:
+
+.. code-block:: bash
+
+    composer require --no-update akeneo/pim-community-dev 4.0.10
+    
 Run the composer update command:
 
 .. code-block:: bash


### PR DESCRIPTION
I would recommand a full CLI command to get a simplest process to update PIM to a specific version.

That allows to play both CE and EE successively without any conflict :
composer require --no-update akeneo/pim-community-dev 4.0.10
composer require --no-update akeneo/pim-enterprise-dev 4.0.10

https://getcomposer.org/doc/03-cli.md#require
--no-update: Disables the automatic update of the dependencies (implies also --no-install: which Does not run the install step after updating the composer.lock file)

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
