### PR TITLE
Fixed namespaces used in "Add A Calculation Step" and improved wording

### DIFF
--- a/manipulate_pim_data/teamwork_assistant/calculation_step.rst
+++ b/manipulate_pim_data/teamwork_assistant/calculation_step.rst
@@ -2,7 +2,7 @@ Add A Calculation Step
 ======================
 
 To add a new step you just need to create a new Step Class that implements
-`Akeneo\\Pim\\WorkOrganization\\TeamworkAssistant\\Componen\t\Job\\ProjectCalculation\\CalculationStep` interface.
+`Akeneo\\Pim\\WorkOrganization\\TeamworkAssistant\\Component\\Job\\ProjectCalculation\\CalculationStep` interface.
 
 .. code-block:: php
 

--- a/manipulate_pim_data/teamwork_assistant/calculation_step.rst
+++ b/manipulate_pim_data/teamwork_assistant/calculation_step.rst
@@ -2,7 +2,7 @@ Add A Calculation Step
 ======================
 
 To add a new step you just need to create a new Step Class that implements
-`Akeneo\\Pim\\WorkOrganization\\TeamworkAssistant\\Component\\Job\\ProjectCalculation\\CalculationStep` interface.
+`Akeneo\\Pim\\WorkOrganization\\TeamworkAssistant\\Component\\Job\\ProjectCalculation\\CalculationStep\\CalculationStepInterface` interface.
 
 .. code-block:: php
 

--- a/manipulate_pim_data/teamwork_assistant/calculation_step.rst
+++ b/manipulate_pim_data/teamwork_assistant/calculation_step.rst
@@ -2,7 +2,7 @@ Add A Calculation Step
 ======================
 
 To add a new step you just need to create a new Step Class that implements
-`PimEnterprise\Component\ActivityManager\Job\ProjectCalculation\CalculationStep\CalculationStepInterface` interface.
+`Akeneo\\Pim\\WorkOrganization\\TeamworkAssistant\\Componen\t\Job\\ProjectCalculation\\CalculationStep` interface.
 
 .. code-block:: php
 
@@ -25,16 +25,16 @@ To add a new step you just need to create a new Step Class that implements
     }
 
 For example, we created the
-`PimEnterprise\Component\ActivityManager\Job\ProjectCalculation\CalculationStep\LoggableStep` for debug purposes.
-It allows to log the memory usage for each loop of the
-`PimEnterprise\Component\ActivityManager\Job\ProjectCalculation\ProjectCalculationTasklet`. It helped us to hunt
+`Akeneo\\Pim\\WorkOrganization\\TeamworkAssistant\\Component\\Job\\ProjectCalculation\\CalculationStep\\LoggableStep` for debug purposes.
+It allows logging the memory usage for each loop of the
+`Akeneo\\Pim\\WorkOrganization\\TeamworkAssistant\\Component\\Job\\ProjectCalculation\\ProjectCalculationTasklet`. It helped us to hunt
 memory leaks. Don't hesitate to use it to check your custom calculation step.
 
 .. code-block:: php
 
-    <?php // src/PimEnterprise/Component/ActivityManager/Job/ProjectCalculation/CalculationStep/LoggableStep.php
+    <?php // src/Akeneo/Pim/WorkOrganization/TeamworkAssistant/Component/Job/ProjectCalculation/CalculationStep/LoggableStep.php
 
-    namespace PimEnterprise\Component\ActivityManager\Job\ProjectCalculation\CalculationStep;
+    namespace Akeneo\Pim\WorkOrganization\TeamworkAssistant\Component\Job\ProjectCalculation\CalculationStep;
 
     use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
     use Akeneo\Pim\WorkOrganization\TeamworkAssistant\Component\Model\ProjectInterface;
@@ -84,7 +84,7 @@ Or for the `LoggableStep`:
 .. code-block:: yaml
 
     activity_manager.calculation_step.loggable_step:
-        class: 'PimEnterprise\Component\ActivityManager\Job\ProjectCalculation\CalculationStep\LoggableStep'
+        class: 'Akeneo\Pim\WorkOrganization\TeamworkAssistant\Component\Job\ProjectCalculation\CalculationStep\LoggableStep'
         arguments:
             - '/your/custom/path/memory_leak_hunter.csv'
         public: false


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

* Teamwork assistant classes were moved to `Akeneo\Pim\WorkOrganization\TeamworkAssistant` namespace in Akeneo 4 but it wasn't reflected in the documentation
* Slashes must be doubled to be properly rendered in the markdown documentation
* Slight changes in wording: "allows to log" -> "allows logging"

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
