### PR TITLE
PIM-9588: Improve add new property to category doc

### DIFF
--- a/manipulate_pim_data/category/add_new_properties_to_a_category.rst
+++ b/manipulate_pim_data/category/add_new_properties_to_a_category.rst
@@ -129,9 +129,11 @@ You also need to update the controller dependency injection:
                 - '@pim_catalog.factory.category'
                 - '@pim_catalog.repository.category'
                 - '@oro_security.security_facade'
+                - '@translator'
                 - { related_entity: product, form_type: 'Acme\Bundle\CatalogBundle\Form\Type\CategoryType', acl: pim_enrich_product, route: pim_enrich }
             calls:
                 - [ setContainer, [ '@service_container' ] ]
+            public: true
 
 Then, add this new file to your dependency injection extension:
 
@@ -322,9 +324,11 @@ You also need to update the controller dependency injection:
                 - '@pim_catalog.factory.category'
                 - '@pim_catalog.repository.category'
                 - '@oro_security.security_facade'
+                - '@translator'
                 - { related_entity: product, form_type: 'Acme\Bundle\CatalogBundle\Form\Type\CategoryType', acl: pim_enrich_product, route: pim_enrich }
             calls:
                 - [ setContainer, [ '@service_container' ] ]
+            public: true
 
 Then, don't forget to add your new field to the twig template:
 

--- a/manipulate_pim_data/category/add_new_properties_to_a_category.rst
+++ b/manipulate_pim_data/category/add_new_properties_to_a_category.rst
@@ -19,7 +19,7 @@ For example, we can add a description property with a text field.
 
 .. literalinclude:: ../../src/Acme/Bundle/CatalogBundle/Entity/Category.php
    :language: php
-   :prepend: # /src/Acme/Bundle/CatalogBundle/Entity/Category.php
+   :prepend: // /src/Acme/Bundle/CatalogBundle/Entity/Category.php
    :linenos:
 
 Configure the mapping override
@@ -36,7 +36,7 @@ You also need to configure the mapping override in your application configuratio
 
 .. code-block:: yaml
 
-    # app/config/config.yml
+    # config/services/storage_utils.yml
     akeneo_storage_utils:
         mapping_overrides:
             -
@@ -59,7 +59,7 @@ You need to update your category entity parameter used in ``entities.yml`` file:
 
    .. code-block:: php
 
-       # /src/Acme/Bundle/CatalogBundle/DependencyInjection/AcmeAppExtension.php
+       // /src/Acme/Bundle/CatalogBundle/DependencyInjection/AcmeAppExtension.php
        public function load(array $configs, ContainerBuilder $container)
        {
            /** ... **/
@@ -70,7 +70,7 @@ You need to update your category entity parameter used in ``entities.yml`` file:
    You don't have to add a lot of code to the Doctrine configuration to resolve target entities.
    We already have a resolver which injects the new category class name.
 
-Now, you can run the following commands to update your database:
+Now, you can run the following commands to update your database: (don't forget to register your new bundle in the `config/bundles.php` file)
 
 .. code-block:: bash
 
@@ -84,7 +84,7 @@ Firstly, you have to create your custom type by inheriting the CategoryType clas
 
 .. literalinclude:: ../../src/Acme/Bundle/EnrichBundle/Form/Type/CategoryType.php
     :language: php
-    :prepend: # /src/Acme/Bundle/EnrichBundle/Form/Type/CategoryType.php
+    :prepend: // /src/Acme/Bundle/EnrichBundle/Form/Type/CategoryType.php
     :linenos:
 
 Then, you have to override the service definition of your form:
@@ -105,7 +105,7 @@ Then, add this new file to your dependency injection extension:
 
 .. code-block:: php
 
-    # /src/Acme/Bundle/EnrichBundle/DependencyInjection/AcmeAppExtension.php
+    // /src/Acme/Bundle/EnrichBundle/DependencyInjection/AcmeAppExtension.php
     public function load(array $configs, ContainerBuilder $container)
     {
         /** ... **/
@@ -175,14 +175,14 @@ For example, we can add an optional description property with a text field.
 
 .. literalinclude:: ../../src/Acme/Bundle/CatalogBundle/Entity/CategoryTranslation.php
    :language: php
-   :prepend: # /src/Acme/Bundle/CatalogBundle/Entity/CategoryTranslation.php
+   :prepend: // /src/Acme/Bundle/CatalogBundle/Entity/CategoryTranslation.php
    :linenos:
 
 Then we need to link this description to the ``Category`` class.
 
 .. literalinclude:: ../../src/Acme/Bundle/CatalogBundle/Entity/TranslatableCategory.php
    :language: php
-   :prepend: # /src/Acme/Bundle/CatalogBundle/Entity/Category.php
+   :prepend: // /src/Acme/Bundle/CatalogBundle/Entity/Category.php
    :linenos:
 
 Configure the mapping override
@@ -206,7 +206,7 @@ You also need to configure the mapping override in your application configuratio
 
 .. code-block:: yaml
 
-    # app/config/config.yml
+    # config/services/storage_utils.yml
     akeneo_storage_utils:
         mapping_overrides:
             -
@@ -232,7 +232,7 @@ You need to update your category entity parameter used in ``entities.yml`` file:
 
    .. code-block:: php
 
-       # /src/Acme/Bundle/CatalogBundle/DependencyInjection/AcmeAppExtension.php
+       // /src/Acme/Bundle/CatalogBundle/DependencyInjection/AcmeAppExtension.php
        public function load(array $configs, ContainerBuilder $container)
        {
            /** ... **/
@@ -257,7 +257,7 @@ Firstly, you have to create your custom type by inheriting the CategoryType clas
 
 .. literalinclude:: ../../src/Acme/Bundle/EnrichBundle/Form/Type/TranslatableCategoryType.php
     :language: php
-    :prepend: # /src/Acme/Bundle/EnrichBundle/Form/Type/CategoryType.php
+    :prepend: // /src/Acme/Bundle/EnrichBundle/Form/Type/CategoryType.php
     :linenos:
 
 Then, you have to override the service definition of your form:
@@ -278,7 +278,7 @@ Then, add this new file to your dependency injection extension:
 
 .. code-block:: php
 
-    # /src/Acme/Bundle/EnrichBundle/DependencyInjection/AcmeAppExtension.php
+    // /src/Acme/Bundle/EnrichBundle/DependencyInjection/AcmeAppExtension.php
     public function load(array $configs, ContainerBuilder $container)
     {
         /** ... **/

--- a/manipulate_pim_data/category/add_new_properties_to_a_category.rst
+++ b/manipulate_pim_data/category/add_new_properties_to_a_category.rst
@@ -36,7 +36,7 @@ You also need to configure the mapping override in your application configuratio
 
 .. code-block:: yaml
 
-    # config/services/storage_utils.yml
+    # /config/services/storage_utils.yml
     akeneo_storage_utils:
         mapping_overrides:
             -
@@ -55,22 +55,30 @@ You need to update your category entity parameter used in ``entities.yml`` file:
    :linenos:
 
 .. important::
-   If you are creating a new bundle, double check that this file is inside the extension
+   If you are creating a new bundle, double check that this ``entities.yml`` file is loaded in your bundle extension and that your new bundle is registered in your application ``/config/bundles.php`` file
 
    .. code-block:: php
 
-       // /src/Acme/Bundle/CatalogBundle/DependencyInjection/AcmeCatalogExtension.php
-       public function load(array $configs, ContainerBuilder $container)
-       {
-           /** ... **/
-           $loader->load('entities.yml');
-       }
+        // /src/Acme/Bundle/CatalogBundle/DependencyInjection/AcmeCatalogExtension.php
+        public function load(array $configs, ContainerBuilder $container)
+        {
+            /** ... **/
+            $loader->load('entities.yml');
+        }
+
+    .. code-block:: php
+
+        // /config/bundles.php
+        return [
+            /** ... **/
+            Acme\Bundle\CatalogBundle\AcmeCatalogBundle::class => ['all' => true],
+        ];
 
 .. note::
    You don't have to add a lot of code to the Doctrine configuration to resolve target entities.
    We already have a resolver which injects the new category class name.
 
-Now, you can run the following commands to update your database: (don't forget to register your new bundle in the `config/bundles.php` file)
+Now, you can run the following commands to update your database:
 
 .. code-block:: bash
 

--- a/src/Acme/Bundle/CatalogBundle/Form/Type/CategoryType.php
+++ b/src/Acme/Bundle/CatalogBundle/Form/Type/CategoryType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Acme\Bundle\EnrichBundle\Form\Type;
+namespace Acme\Bundle\CatalogBundle\Form\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;

--- a/src/Acme/Bundle/CatalogBundle/Form/Type/TranslatableCategoryType.php
+++ b/src/Acme/Bundle/CatalogBundle/Form/Type/TranslatableCategoryType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Acme\Bundle\EnrichBundle\Form\Type;
+namespace Acme\Bundle\CatalogBundle\Form\Type;
 
 use Symfony\Component\Form\FormBuilderInterface;
 

--- a/src/Acme/Bundle/CatalogBundle/Resources/config/form_types.yml
+++ b/src/Acme/Bundle/CatalogBundle/Resources/config/form_types.yml
@@ -1,0 +1,2 @@
+parameters:
+  pim_enrich.view_element.category.tab.property.template: 'AcmeCatalogBundle:CategoryTree:Tab/property.html.twig'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**
In this PR:
- The issue comes from the config override, I believe that putting the `akeneo_storage_utils` block in `config/services/prod` is wrong as it is not environment-dependent. When putting the override block in `config/services/storage_utils.yml`, the SQL dump works as intended:

    The following SQL statements will be executed:

         ALTER TABLE pim_catalog_category ADD description VARCHAR(255) DEFAULT NULL;
         …

- adding a reminder to register the new Bundle in the app kernel config/bundles.php file.
- There is some part that reference EnrichmentBundle whereas the rest of the tutorial reference CatalogBundle => move all to CatalogBundle
- The Extension file of bundle is not AcmeAppExtension but AcmeCatalogExtension

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
