### PR TITLE
BH-377 Fixes ref to old Docker image and cleanup

### DIFF
--- a/install_pim/docker/installation_docker.rst
+++ b/install_pim/docker/installation_docker.rst
@@ -51,7 +51,7 @@ The following command will create a PIM project in the current directory. Please
     $ cd pim
     $ docker run -ti -u www-data --rm \
         -v $(pwd):/srv/pim -v ~/.composer:/var/www/.composer -w /srv/pim \
-        akeneo/pim-php-dev:5.0 php -d memory_limit=4G /usr/local/bin/composer create-project \
+        akeneo/pim-php-dev:5.0 php /usr/local/bin/composer create-project \
         akeneo/pim-community-standard /srv/pim "5.0.*@stable"
 
 .. note::
@@ -70,7 +70,7 @@ You need to get a PIM Enterprise Standard archive from the Partners Portal. See 
     $ cd pim-enterprise-standard
     $ docker run -ti -u www-data --rm \
         -v $(pwd):/srv/pim -v ~/.composer:/var/www/.composer -v ~/.ssh:/var/www/.ssh -w /srv/pim \
-        akeneo/pim-php-dev:5.0 php -d memory_limit=4G /usr/local/bin/composer install
+        akeneo/pim-php-dev:5.0 php /usr/local/bin/composer install
 
 .. note::
     The above Docker command uses a volume to make your SSH private key available to the container, in order for it to access
@@ -80,8 +80,8 @@ You need to get a PIM Enterprise Standard archive from the Partners Portal. See 
 
     .. code-block:: bash
 
-        $ docker run -ti -u www-data -v $(pwd):/srv/pim -v $SSH_AUTH_SOCK:/ssh-auth.sock -e SSH_AUTH_SOCK=/ssh-auth.sock -w /srv/pim --rm akeneo/pim-php-dev:4.0 \
-            php -d memory_limit=4G /usr/local/bin/composer install
+        $ docker run -ti -u www-data -v $(pwd):/srv/pim -v $SSH_AUTH_SOCK:/ssh-auth.sock -e SSH_AUTH_SOCK=/ssh-auth.sock -w /srv/pim --rm akeneo/pim-php-dev:5.0 \
+            /usr/local/bin/composer install
 
     See https://github.com/docker-library/docs/tree/master/composer/#private-repositories--ssh-agent for more details.
 

--- a/install_pim/manual/installation_ce.rst
+++ b/install_pim/manual/installation_ce.rst
@@ -11,9 +11,8 @@ You can either use `composer` to create your project:
 .. code-block:: bash
    :linenos:
 
-   $ php -d memory_limit=4G /usr/local/bin/composer create-project --prefer-dist \
-        akeneo/pim-community-standard /srv/pim "4.0.*@stable"
+   $ composer create-project akeneo/pim-community-standard /srv/pim "5.0.*@stable"
 
-or download an archive containing Akeneo PIM and its PHP dependencies: https://download.akeneo.com/pim-community-standard-v4.0-latest-icecat.tar.gz
+or download an archive containing Akeneo PIM and its PHP dependencies: https://download.akeneo.com/pim-community-standard-v5.0-latest-icecat.tar.gz
 
 .. include:: ./common_install_ce_ee.rst.inc

--- a/install_pim/manual/installation_ee_archive.rst
+++ b/install_pim/manual/installation_ee_archive.rst
@@ -12,8 +12,8 @@ You need to get a PIM Enterprise Standard archive from the Partners Portal. See 
 
 .. code-block:: bash
 
-    $ tar -xvzf pim-enterprise-standard-v4.0.tar.gz
+    $ tar -xvzf pim-enterprise-standard-v5.0.tar.gz
     $ cd pim-enterprise-standard/pim-enterprise-standard
-    $ php -d memory_limit=4G /usr/local/bin/composer install
+    $ composer install
 
 .. include:: ./common_install_ce_ee.rst.inc


### PR DESCRIPTION
**Description**

This PR fixes references to 4.0 Docker image. And do some cleanup: as we are using composer 2, no need to increase memory.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | -


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
