### PR TITLE
PIM-9735: Troubeshooting - Fix asset family identifiers command

### DIFF
--- a/troubleshooting/index.rst
+++ b/troubleshooting/index.rst
@@ -15,3 +15,18 @@ you must apply this fix with the following MySql ALTER command:
 .. code-block:: sql
 
    ALTER TABLE pim_catalog_completeness MODIFY id bigint NOT NULL AUTO_INCREMENT;
+
+
+Asset family identifiers stored with a different case in attributes properties (EE only)
+----------------------------------------------------------------------------------------
+
+.. note::
+
+   Impacted versions: PIM EE <= 5.0
+
+We fixed the attributes import to sanitize the asset family identifiers, but if you need to fix data already stored
+in database, we provide a tooling command to clean this data:
+
+.. code-block:: sql
+
+   bin/console --env=prod pim:asset-manager:clean-asset-family-in-asset-collection-attributes

--- a/troubleshooting/index.rst
+++ b/troubleshooting/index.rst
@@ -24,8 +24,8 @@ Asset family identifiers stored with a different case in attributes properties (
 
    Impacted versions: PIM EE <= 5.0
 
-We fixed the attributes import to sanitize the asset family identifiers, but if you need to fix data already stored
-in database, we provide a tooling command to clean this data:
+We fixed the attributes import to sanitize the asset family identifiers in PIM-9753,
+and you may need to fix data already stored in database with the following clean command:
 
 .. code-block:: sql
 


### PR DESCRIPTION
Fix asset family identifiers stored with a different case in attributes properties
