### PR TITLE
PIM-9775: Troubleshooting: Asset codes filtering being case sensitive

### DIFF
--- a/troubleshooting/index.rst
+++ b/troubleshooting/index.rst
@@ -27,7 +27,7 @@ Asset family identifiers stored with a different case in attributes properties (
 We fixed the attributes import to sanitize the asset family identifiers in PIM-9753,
 and you may need to fix data already stored in database with the following clean command:
 
-.. code-block:: sql
+.. code-block:: bash
 
    bin/console --env=prod pim:asset-manager:clean-asset-family-in-asset-collection-attributes
 
@@ -42,7 +42,7 @@ Asset & Asset family codes being case-sensitive (EE only)
 The Asset index mapping has been updated to be case-insensitive on the Asset & Asset family codes.
 You may need to reset your index and re-index all Assets:
 
-.. code-block:: sql
+.. code-block:: bash
 
    bin/console akeneo:elasticsearch:reset-indexes --index=akeneo_assetmanager_asset
    bin/console akeneo:asset-manager:index-assets --all

--- a/troubleshooting/index.rst
+++ b/troubleshooting/index.rst
@@ -30,3 +30,19 @@ and you may need to fix data already stored in database with the following clean
 .. code-block:: sql
 
    bin/console --env=prod pim:asset-manager:clean-asset-family-in-asset-collection-attributes
+
+
+Asset & Asset family codes being case-sensitive (EE only)
+----------------------------------------------------------------------------------------
+
+.. note::
+
+   Impacted versions: PIM EE <= 5.0
+
+The Asset index mapping has been updated to be case-insensitive on the Asset & Asset family codes.
+You may need to reset your index and re-index all Assets:
+
+.. code-block:: sql
+
+   bin/console akeneo:elasticsearch:reset-indexes --index=akeneo_assetmanager_asset
+   bin/console akeneo:asset-manager:index-assets --all


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

Troubleshooting guide on how to reset & re-index Assets

See https://github.com/akeneo/pim-enterprise-dev/pull/10592

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
