### PR TITLE
remove duplicate zip package

### DIFF
--- a/install_pim/manual/system_requirements/manual_system_installation_debian10.rst
+++ b/install_pim/manual/system_requirements/manual_system_installation_debian10.rst
@@ -43,7 +43,7 @@ Install PHP and the required extensions:
 
 .. code-block:: bash
 
-    # apt-get install php7.3-cli php7.3-apcu php7.3-bcmath php7.3-curl php7.3-fpm php7.3-gd php7.3-intl php7.3-mysql php7.3-xml php7.3-zip php7.3-zip php7.3-mbstring php7.3-imagick php7.3-exif
+    # apt-get install php7.3-cli php7.3-apcu php7.3-bcmath php7.3-curl php7.3-fpm php7.3-gd php7.3-intl php7.3-mysql php7.3-xml php7.3-zip php7.3-mbstring php7.3-imagick php7.3-exif
 
 Elasticsearch 7.5
 *****************


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**
While skimming the docs, I spotted a command line with two consecutive occurences of the php-zip package. This PR suggests a small cleaning.
<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
