### PR TITLE
Update front.rst

### DIFF
--- a/contribute_to_pim/front.rst
+++ b/contribute_to_pim/front.rst
@@ -86,7 +86,7 @@ What to do if I updated a form_extension**.yml file?
 .. code-block:: bash
 
     rm -rf var/cache
-    bin/console --env=prod pim:installer:dump-extensions
+    yarn update-extensions
     yarn webpack-dev
 
 What to do if I updated a requirejs.yml file?


### PR DESCRIPTION
The command dump-extension do not exist in version 5..

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

Update documentation which is referencing to wrong command

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
