### PR TITLE
#1682 - Fixing form_extensions and slightly improving the guide

### DIFF
--- a/import_and_export_data/guides/product-import-from-xml-file.rst
+++ b/import_and_export_data/guides/product-import-from-xml-file.rst
@@ -107,9 +107,15 @@ Then you will need to add the job parameters classes (they define the job config
    :language: php
    :linenos:
 
+In your bundle, create the following form_extensions :
+
+Resources/config/form_extensions/job_instance/xml_product_import_edit.yml with the following content:
+
 .. literalinclude:: ../../src/Acme/Bundle/XmlConnectorBundle/Resources/config/form_extensions/job_instance/xml_product_import_edit.yml
   :language: yaml
   :linenos:
+
+And Resources/config/form_extensions/job_instance/xml_product_import_show.yml with the following content:
 
 .. literalinclude:: ../../src/Acme/Bundle/XmlConnectorBundle/Resources/config/form_extensions/job_instance/xml_product_import_show.yml
    :language: yaml

--- a/src/Acme/Bundle/XmlConnectorBundle/Resources/config/form_extensions/job_instance/xml_product_import_edit.yml
+++ b/src/Acme/Bundle/XmlConnectorBundle/Resources/config/form_extensions/job_instance/xml_product_import_edit.yml
@@ -2,6 +2,28 @@ extensions:
     pim-job-instance-xml-product-import-edit:
         module: pim/form/common/edit-form
 
+    pim-job-instance-xml-product-import-edit-main-image:
+        module: pim/form/common/main-image
+        parent: pim-job-instance-xml-product-import-edit
+        targetZone: main-image
+        config:
+            path: bundles/pimui/images/illustrations/ImportCSV.svg
+
+    pim-job-instance-xml-product-import-edit-user-navigation:
+        module: pim/menu/user-navigation
+        parent: pim-job-instance-xml-product-import-edit
+        targetZone: user-menu
+        config:
+            userAccount: pim_menu.user.user_account
+            logout: pim_menu.user.logout
+
+    pim-job-instance-xml-product-import-edit-breadcrumbs:
+        module: pim/common/breadcrumbs
+        parent: pim-job-instance-xml-product-import-edit
+        targetZone: breadcrumbs
+        config:
+            tab: pim-menu-imports
+
     pim-job-instance-xml-product-import-edit-cache-invalidator:
         module: pim/cache-invalidator
         parent: pim-job-instance-xml-product-import-edit
@@ -20,18 +42,28 @@ extensions:
         targetZone: container
         position: 100
         config:
-            tabTitle: pim_enrich.form.job_instance.tab.properties.title
+            tabTitle: pim_common.properties
             tabCode: pim-job-instance-properties
+
+    pim-job-instance-xml-product-import-edit-global:
+        module: pim/job/common/edit/properties
+        parent: pim-job-instance-xml-product-import-edit-tabs
+        aclResourceId: pim_importexport_export_profile_property_edit
+        targetZone: container
+        position: 120
+        config:
+            tabTitle: pim_enrich.export.product.global_settings.title
+            tabCode: pim-job-instance-global
 
     pim-job-instance-xml-product-import-edit-history:
         module: pim/common/tab/history
         parent: pim-job-instance-xml-product-import-edit-tabs
         targetZone: container
         aclResourceId: pim_importexport_import_profile_history
-        position: 120
+        position: 130
         config:
             class: Akeneo\Tool\Component\Batch\Model\JobInstance
-            title: pim_enrich.form.job_instance.tab.history.title
+            title: pim_common.history
             tabCode: pim-job-instance-history
 
     pim-job-instance-xml-product-import-edit-properties-code:
@@ -41,7 +73,7 @@ extensions:
         targetZone: properties
         config:
             fieldCode: code
-            label: pim_enrich.form.job_instance.tab.properties.code.title
+            label: pim_common.code
             readOnly: true
 
     pim-job-instance-xml-product-import-edit-properties-label:
@@ -51,118 +83,128 @@ extensions:
         targetZone: properties
         config:
             fieldCode: label
-            label: pim_enrich.form.job_instance.tab.properties.label.title
+            label: pim_common.label
 
     pim-job-instance-xml-product-import-edit-properties-file-path:
-        module: pim/job/common/edit/field/text
-        parent: pim-job-instance-xml-product-import-edit-properties
+        module: pim/job/common/edit/field/file-path
+        parent: pim-job-instance-xml-product-import-edit-global
         position: 120
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.filePath
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+            label: pim_import_export.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help_import
 
     pim-job-instance-xml-product-import-edit-properties-file-upload:
-        module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-xml-product-import-edit-properties
+        module: pim/job/common/edit/field/allow-file-upload
+        parent: pim-job-instance-xml-product-import-edit-global
         position: 130
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.uploadAllowed
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
-            readOnly: false
+            label: pim_import_export.form.job_instance.tab.properties.upload_allowed.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-xml-product-import-edit-properties-decimal-separator:
         module: pim/job/common/edit/field/decimal-separator
-        parent: pim-job-instance-xml-product-import-edit-properties
+        parent: pim-job-instance-xml-product-import-edit-global
         position: 170
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.decimalSeparator
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+            label: pim_import_export.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.decimal_separator.help
 
     pim-job-instance-xml-product-import-edit-properties-date-format:
         module: pim/job/product/edit/field/date-format
-        parent: pim-job-instance-xml-product-import-edit-properties
+        parent: pim-job-instance-xml-product-import-edit-global
         position: 180
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.dateFormat
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+            label: pim_import_export.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-xml-product-import-edit-properties-enabled:
         module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-xml-product-import-edit-properties
+        parent: pim-job-instance-xml-product-import-edit-global
         position: 190
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.enabled
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enabled.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
+            label: pim_import_export.form.job_instance.tab.properties.enabled.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.enabled.help
 
     pim-job-instance-xml-product-import-edit-properties-categories-column:
         module: pim/job/common/edit/field/text
-        parent: pim-job-instance-xml-product-import-edit-properties
+        parent: pim-job-instance-xml-product-import-edit-global
         position: 200
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.categoriesColumn
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.categories_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.categories_column.help
+            label: pim_import_export.form.job_instance.tab.properties.categories_column.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.categories_column.help
 
     pim-job-instance-xml-product-import-edit-properties-family-column:
         module: pim/job/common/edit/field/text
-        parent: pim-job-instance-xml-product-import-edit-properties
+        parent: pim-job-instance-xml-product-import-edit-global
         position: 210
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.familyColumn
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.family_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.family_column.help
+            label: pim_import_export.form.job_instance.tab.properties.family_column.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.family_column.help
 
     pim-job-instance-xml-product-import-edit-properties-groups-column:
         module: pim/job/common/edit/field/text
-        parent: pim-job-instance-xml-product-import-edit-properties
+        parent: pim-job-instance-xml-product-import-edit-global
         position: 220
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.groupsColumn
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.groups_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.groups_column.help
+            label: pim_import_export.form.job_instance.tab.properties.groups_column.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.groups_column.help
 
     pim-job-instance-xml-product-import-edit-properties-enabled-comparison:
         module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-xml-product-import-edit-properties
+        parent: pim-job-instance-xml-product-import-edit-global
         position: 230
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.enabledComparison
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enabled_comparison.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enabled_comparison.help
+            label: pim_import_export.form.job_instance.tab.properties.enabled_comparison.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.enabled_comparison.help
 
     pim-job-instance-xml-product-import-edit-properties-real-time-versioning:
         module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-xml-product-import-edit-properties
+        parent: pim-job-instance-xml-product-import-edit-global
         position: 240
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.realTimeVersioning
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.real_time_versioning.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.real_time_versioning.help
+            label: pim_import_export.form.job_instance.tab.properties.real_time_versioning.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.real_time_versioning.help
+
+    pim-job-instance-xml-product-import-edit-properties-convert-variant-to-simple:
+        module: pim/job/common/edit/field/switch
+        parent: pim-job-instance-xml-product-import-edit-global
+        position: 250
+        targetZone: properties
+        config:
+            fieldCode: configuration.convertVariantToSimple
+            readOnly: false
+            label: pim_import_export.form.job_instance.tab.properties.convert_variant_to_simple.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.convert_variant_to_simple.help
 
     pim-job-instance-xml-product-import-edit-label:
         module: pim/job/common/edit/label
@@ -176,26 +218,23 @@ extensions:
         targetZone: meta
         position: 100
 
-    pim-job-instance-xml-product-import-edit-back-to-grid:
-        module: pim/form/common/back-to-grid
+    pim-job-instance-xml-product-import-edit-secondary-actions:
+        module: pim/form/common/secondary-actions
         parent: pim-job-instance-xml-product-import-edit
-        targetZone: back
-        aclResourceId: pim_importexport_import_profile_index
-        position: 80
-        config:
-            backUrl: pim_importexport_import_profile_index
+        targetZone: buttons
+        position: 50
 
     pim-job-instance-xml-product-import-edit-delete:
         module: pim/job/import/edit/delete
-        parent: pim-job-instance-xml-product-import-edit
-        targetZone: buttons
+        parent: pim-job-instance-xml-product-import-edit-secondary-actions
+        targetZone: secondary-actions
         aclResourceId: pim_importexport_import_profile_remove
         position: 100
         config:
             trans:
-                title: confirmation.remove.job_instance
-                content: pim_enrich.confirmation.delete_item
-                success: flash.job_instance.removed
+                title: confirmation.remove.import_profile
+                content: pim_common.confirm_deletion
+                success: pim_import_export.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_import_profile_index
 
@@ -219,7 +258,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.label
 
     pim-job-instance-xml-product-import-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Acme/Bundle/XmlConnectorBundle/Resources/config/form_extensions/job_instance/xml_product_import_show.yml
+++ b/src/Acme/Bundle/XmlConnectorBundle/Resources/config/form_extensions/job_instance/xml_product_import_show.yml
@@ -2,169 +2,106 @@ extensions:
     pim-job-instance-xml-product-import-show:
         module: pim/form/common/edit-form
 
-    pim-job-instance-xml-product-import-show-tabs:
-        module: pim/form/common/form-tabs
+    pim-job-instance-xml-product-import-show-main-image:
+        module: pim/form/common/main-image
+        parent: pim-job-instance-xml-product-import-show
+        targetZone: main-image
+        config:
+            path: bundles/pimui/images/illustrations/ImportCSV.svg
+
+    pim-job-instance-xml-product-import-show-user-navigation:
+        module: pim/menu/user-navigation
+        parent: pim-job-instance-xml-product-import-show
+        targetZone: user-menu
+        config:
+            userAccount: pim_menu.user.user_account
+            logout: pim_menu.user.logout
+
+    pim-job-instance-xml-product-import-show-breadcrumbs:
+        module: pim/common/breadcrumbs
+        parent: pim-job-instance-xml-product-import-show
+        targetZone: breadcrumbs
+        config:
+            tab: pim-menu-imports
+
+    pim-job-instance-xml-product-import-show-switcher:
+        module: pim/job-instance/import/switcher
+        parent: pim-job-instance-xml-product-import-show
+        position: 0
+        targetZone: meta
+
+    pim-job-instance-xml-product-import-show-launch-switcher-item:
+        module: pim/job-instance/import/switcher-item
         parent: pim-job-instance-xml-product-import-show
         targetZone: content
-        position: 100
+        aclResourceId: pim_importexport_import_profile_launch
+        position: 40
+        config:
+            label: pim_import_export.form.job_instance.button.import.launch
+            hideForCloudEdition: true
+
+    pim-job-instance-xml-product-import-show-file-path:
+        module: pim/job/common/file-path
+        parent: pim-job-instance-xml-product-import-show-launch-switcher-item
+        config:
+            label: pim_import_export.form.job_instance.file_path
+
+    pim-job-instance-xml-product-import-show-import-button:
+        module: pim/job/common/edit/launch
+        parent: pim-job-instance-xml-product-import-show-file-path
+        targetZone: buttons
+        config:
+            label: pim_import_export.form.job_instance.button.import.launch
+            route: pim_enrich_job_instance_rest_import_launch
+            identifier:
+                path: code
+                name: code
+
+    pim-job-instance-xml-product-import-show-upload-switcher-item:
+        module: pim/job-instance/import/switcher-item
+        parent: pim-job-instance-xml-product-import-show
+        targetZone: content
+        aclResourceId: pim_importexport_import_profile_launch
+        position: 50
+        config:
+            allowedKey: uploadAllowed
+            label: pim_import_export.form.job_instance.button.import.upload_file
+            hideForCloudEdition: false
 
     pim-job-instance-xml-product-import-show-upload:
         module: pim/job/common/edit/upload
+        parent: pim-job-instance-xml-product-import-show-upload-switcher-item
+        position: 50
+        config:
+            type: xml
+
+    pim-job-instance-xml-product-import-show-upload-button:
+        module: pim/job/common/edit/upload-launch
+        parent: pim-job-instance-xml-product-import-show-upload-switcher-item
+        position: 60
+        config:
+            label: pim_import_export.form.job_instance.button.import.upload
+            route: pim_enrich_job_instance_rest_import_launch
+            identifier:
+                path: code
+                name: code
+
+    pim-job-instance-xml-product-import-show-subsection:
+        module: pim/form/common/subsection
         parent: pim-job-instance-xml-product-import-show
-        aclResourceId: pim_importexport_import_profile_launch
         targetZone: content
-        position: 90
-
-    pim-job-instance-xml-product-import-show-properties:
-        module: pim/job/common/edit/properties
-        parent: pim-job-instance-xml-product-import-show-tabs
-        aclResourceId: pim_importexport_export_profile_property_show
-        targetZone: container
-        position: 100
         config:
-            tabTitle: pim_enrich.form.job_instance.tab.properties.title
-            tabCode: pim-job-instance-properties
+            title: pim_import_export.form.job_instance.subsection.last_executions
 
-    pim-job-instance-xml-product-import-show-history:
-        module: pim/common/tab/history
-        parent: pim-job-instance-xml-product-import-show-tabs
-        targetZone: container
-        aclResourceId: pim_importexport_import_profile_history
-        position: 120
+    pim-job-instance-xml-product-import-show-grid:
+        module: pim/job/common/grid
+        parent: pim-job-instance-xml-product-import-show-subsection
+        position: 1000
+        targetZone: content
         config:
-            class: Akeneo\Tool\Component\Batch\Model\JobInstance
-            title: pim_enrich.form.job_instance.tab.history.title
-            tabCode: pim-job-instance-history
-
-    pim-job-instance-xml-product-import-show-properties-code:
-        module: pim/job/common/edit/field/text
-        parent: pim-job-instance-xml-product-import-show-properties
-        position: 100
-        targetZone: properties
-        config:
-            fieldCode: code
-            label: pim_enrich.form.job_instance.tab.properties.code.title
-            readOnly: true
-
-    pim-job-instance-xml-product-import-show-properties-label:
-        module: pim/job/common/edit/field/text
-        parent: pim-job-instance-xml-product-import-show-properties
-        position: 110
-        targetZone: properties
-        config:
-            fieldCode: label
-            label: pim_enrich.form.job_instance.tab.properties.label.title
-            readOnly: true
-
-    pim-job-instance-xml-product-import-show-properties-file-path:
-        module: pim/job/common/edit/field/text
-        parent: pim-job-instance-xml-product-import-show-properties
-        position: 120
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.filePath
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
-
-    pim-job-instance-xml-product-import-show-properties-file-upload:
-        module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-xml-product-import-show-properties
-        position: 130
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.uploadAllowed
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
-
-    pim-job-instance-xml-product-import-show-properties-decimal-separator:
-        module: pim/job/common/edit/field/decimal-separator
-        parent: pim-job-instance-xml-product-import-show-properties
-        position: 170
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.decimalSeparator
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
-
-    pim-job-instance-xml-product-import-show-properties-date-format:
-        module: pim/job/product/edit/field/date-format
-        parent: pim-job-instance-xml-product-import-show-properties
-        position: 180
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.dateFormat
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
-
-    pim-job-instance-xml-product-import-show-properties-enabled:
-        module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-xml-product-import-show-properties
-        position: 190
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.enabled
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.enabled.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
-
-    pim-job-instance-xml-product-import-show-properties-categories-column:
-        module: pim/job/common/edit/field/text
-        parent: pim-job-instance-xml-product-import-show-properties
-        position: 200
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.categoriesColumn
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.categories_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.categories_column.help
-
-    pim-job-instance-xml-product-import-show-properties-family-column:
-        module: pim/job/common/edit/field/text
-        parent: pim-job-instance-xml-product-import-show-properties
-        position: 210
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.familyColumn
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.family_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.family_column.help
-
-    pim-job-instance-xml-product-import-show-properties-groups-column:
-        module: pim/job/common/edit/field/text
-        parent: pim-job-instance-xml-product-import-show-properties
-        position: 220
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.groupsColumn
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.groups_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.groups_column.help
-
-    pim-job-instance-xml-product-import-show-properties-enabled-comparison:
-        module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-xml-product-import-show-properties
-        position: 230
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.enabledComparison
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.enabled_comparison.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enabled_comparison.help
-
-    pim-job-instance-xml-product-import-show-properties-real-time-versioning:
-        module: pim/job/common/edit/field/switch
-        parent: pim-job-instance-xml-product-import-show-properties
-        position: 240
-        targetZone: global-settings
-        config:
-            fieldCode: configuration.realTimeVersioning
-            readOnly: true
-            label: pim_enrich.form.job_instance.tab.properties.real_time_versioning.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.real_time_versioning.help
+            alias: last-import-executions-grid
+            metadata:
+                jobType: import
 
     pim-job-instance-xml-product-import-show-label:
         module: pim/job/common/edit/label
@@ -172,43 +109,16 @@ extensions:
         targetZone: title
         position: 100
 
-    pim-job-instance-xml-product-import-show-meta:
-        module: pim/job/common/edit/meta
-        parent: pim-job-instance-xml-product-import-show
-        targetZone: meta
-        position: 100
-
-    pim-job-instance-xml-product-import-show-back-to-grid:
-        module: pim/form/common/back-to-grid
-        parent: pim-job-instance-xml-product-import-show
-        targetZone: back
-        aclResourceId: pim_importexport_import_profile_index
-        position: 80
-        config:
-            backUrl: pim_importexport_import_profile_index
-
     pim-job-instance-xml-product-import-show-edit:
         module: pim/common/redirect
         parent: pim-job-instance-xml-product-import-show
         targetZone: buttons
         position: 100
+        aclResourceId: pim_importexport_import_profile_edit
         config:
-            label: pim_enrich.form.job_instance.button.edit.title
+            label: pim_common.edit
             route: pim_importexport_import_profile_edit
-            identifier:
-                path: code
-                name: code
-
-    pim-job-instance-xml-product-import-show-launch:
-        module: pim/job/common/edit/upload-launch
-        parent: pim-job-instance-xml-product-import-show
-        aclResourceId: pim_importexport_import_profile_launch
-        targetZone: buttons
-        position: 110
-        config:
-            launch: pim_enrich.form.job_instance.button.import.launch
-            upload: pim_enrich.form.job_instance.button.import.upload
-            route: pim_enrich_job_instance_rest_import_launch
+            buttonClass: AknButton AknButton--action
             identifier:
                 path: code
                 name: code


### PR DESCRIPTION
**Description**

As explained in the issue #1682, some form extensions contents do not work with version 5.0

**Definition Of Done**

* used the csv_product_import_(show/edit).yml as starting point and refined them a bit to match this guide's need.
* added a bit of explanation before the raw form extensions contents in the guide to make it a bit nicer
