### PR TITLE
Fix the Build the UI step in Onboarder installation

### DIFF
--- a/onboarder/installation/index.rst
+++ b/onboarder/installation/index.rst
@@ -53,11 +53,12 @@ Clear the Symfony cache and execute the following command to build the UI:
     rm -rf var/cache/*
     bin/console cache:warmup --env=prod
     rm -rf public/bundles public/js
-    bin/console pim:installer:assets --clean
+    bin/console pim:installer:assets --clean --env=prod
     rm -rf public/css
     yarn run less
     rm -rf public/dist
     yarn run webpack
+    yarn run update-extensions
 
 Make the credential files accessible to Akeneo PIM software
 -----------------------------------------------------------


### PR DESCRIPTION
**Description**

We have noticed that the `extensions.json` file was not generated after running the commands listed in the `Build the UI` step in our installation documentation. In this PR we are adding the `yarn run update-extensions` command in order to regenerate this file.
The `extensions.json` file contains all the form extensions components needed to build the forms.

Same as https://github.com/akeneo/pim-docs/pull/1686 but targetting the `master` branch instead.