### PR TITLE
Use correct PHP image for master install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/
     sh -c 'echo "deb https://packages.sury.org/php/ buster main" > /etc/apt/sources.list.d/php.list' && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        php7.4-apcu php7.4-bcmath php7.4-cli php7.4-curl php7.4-fpm \
-        php7.4-gd php7.4-intl php7.4-mysql php7.4-xml php7.4-zip php7.4-mbstring && \
-    echo "memory_limit = 1024M" >> /etc/php/7.4/cli/php.ini && \
-    echo "date.timezone = UTC" >> /etc/php/7.4/cli/php.ini && \
+        php8.0-apcu php8.0-bcmath php8.0-cli php8.0-curl php8.0-fpm \
+        php8.0-gd php8.0-intl php8.0-mysql php8.0-xml php8.0-zip php8.0-mbstring && \
+    echo "memory_limit = 1024M" >> /etc/php/8.0/cli/php.ini && \
+    echo "date.timezone = UTC" >> /etc/php/8.0/cli/php.ini && \
     apt-get clean && apt-get --yes --quiet autoremove --purge && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/* && \

--- a/install_pim/docker/installation_docker.rst
+++ b/install_pim/docker/installation_docker.rst
@@ -70,7 +70,7 @@ You need to get a PIM Enterprise Standard archive from the Partners Portal. See 
     $ cd pim-enterprise-standard
     $ docker run -ti -u www-data --rm \
         -v $(pwd):/srv/pim -v ~/.composer:/var/www/.composer -v ~/.ssh:/var/www/.ssh -w /srv/pim \
-        akeneo/pim-php-dev:5.0 php /usr/local/bin/composer install
+        akeneo/pim-php-dev:master php /usr/local/bin/composer install
 
 .. note::
     The above Docker command uses a volume to make your SSH private key available to the container, in order for it to access
@@ -80,7 +80,7 @@ You need to get a PIM Enterprise Standard archive from the Partners Portal. See 
 
     .. code-block:: bash
 
-        $ docker run -ti -u www-data -v $(pwd):/srv/pim -v $SSH_AUTH_SOCK:/ssh-auth.sock -e SSH_AUTH_SOCK=/ssh-auth.sock -w /srv/pim --rm akeneo/pim-php-dev:5.0 \
+        $ docker run -ti -u www-data -v $(pwd):/srv/pim -v $SSH_AUTH_SOCK:/ssh-auth.sock -e SSH_AUTH_SOCK=/ssh-auth.sock -w /srv/pim --rm akeneo/pim-php-dev:master \
             /usr/local/bin/composer install
 
     See https://github.com/docker-library/docs/tree/master/composer/#private-repositories--ssh-agent for more details.


### PR DESCRIPTION
The akeneo/pim-php-dev:5.0 use PHP 7.4, not compatible anymore with PIM master