### PR TITLE
PIM-10185: Remove styleguide unused stylesheet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM akeneo/pim-php-dev:5.0
+FROM debian:buster-slim
 WORKDIR /home/akeneo/pim-docs/
 ENV DEBIAN_FRONTEND=noninteractive
-#$BRANCH_NAME
+
 RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/apt.conf.d/01-no-recommended && \
     echo 'path-exclude=/usr/share/man/*' > /etc/dpkg/dpkg.cfg.d/path_exclusions && \
     echo 'path-exclude=/usr/share/doc/*' >> /etc/dpkg/dpkg.cfg.d/path_exclusions && \
@@ -15,41 +15,8 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/
         python ssh rsync curl \
         python-jinja2 \
         python-sphinx && \
-    wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
-    sh -c 'echo "deb https://packages.sury.org/php/ buster main" > /etc/apt/sources.list.d/php.list' #&& \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        php7.4-apcu php7.4-bcmath php7.4-cli php7.4-curl php7.4-fpm \
-        php7.4-gd php7.4-intl php7.4-mysql php7.4-xml php7.4-zip php7.4-mbstring && \
-    echo "memory_limit = 1024M" >> /etc/php/7.4/cli/php.ini && \
-    echo "date.timezone = UTC" >> /etc/php/7.4/cli/php.ini && \
     apt-get clean && apt-get --yes --quiet autoremove --purge && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/* && \
     rm -rf /usr/share/locale/* && \
     rm -rf /var/log/*
-
-#COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
-#RUN chmod +x /usr/local/bin/composer
-
-# Install Akeneo PIM Assets
-#RUN \
-    #
-    # Get PIM CE edition
-    # \
-    #mkdir -p  /home/akeneo/pim-docs  && \
-    #wget https://github.com/akeneo/pim-community-dev/archive/refs/tags/master.zip -P /home/akeneo/pim-docs/ && \
-    #unzip /home/akeneo/pim-docs/master.zip -d /home/akeneo/pim-docs/ && \
-    #cd /home/akeneo/pim-docs/pim-community-dev-5.0.60/ && \
-    #
-    # Install dependencies
-    #
-    #php -d memory_limit=3G /usr/local/bin/composer install --no-suggest --ignore-platform-reqs && \
-    #cd /home/akeneo/pim-docs/pim-community-dev-master/ && php bin/console pim:installer:assets --env=prod && \
-    #mkdir /home/akeneo/pim-docs/pim-community-dev-master/public/css && \
-    #wget http://demo.akeneo.com/css/pim.css -P /home/akeneo/pim-docs/pim-community-dev-master/public/css && \
-    #
-    # Cleanup
-    #
-    #rm -rf /root/.composer/cache && \
-    #cd /home/akeneo/pim-docs/pim-community-dev-master/ && ls | grep -v "vendor\|public" | xargs rm -rf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM debian:buster-slim
+FROM akeneo/pim-php-dev:5.0
 WORKDIR /home/akeneo/pim-docs/
 ENV DEBIAN_FRONTEND=noninteractive
-
+#$BRANCH_NAME
 RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/apt.conf.d/01-no-recommended && \
     echo 'path-exclude=/usr/share/man/*' > /etc/dpkg/dpkg.cfg.d/path_exclusions && \
     echo 'path-exclude=/usr/share/doc/*' >> /etc/dpkg/dpkg.cfg.d/path_exclusions && \
@@ -16,7 +16,7 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/
         python-jinja2 \
         python-sphinx && \
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
-    sh -c 'echo "deb https://packages.sury.org/php/ buster main" > /etc/apt/sources.list.d/php.list' && \
+    sh -c 'echo "deb https://packages.sury.org/php/ buster main" > /etc/apt/sources.list.d/php.list' #&& \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         php7.4-apcu php7.4-bcmath php7.4-cli php7.4-curl php7.4-fpm \
@@ -29,26 +29,27 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/
     rm -rf /usr/share/locale/* && \
     rm -rf /var/log/*
 
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
-RUN chmod +x /usr/local/bin/composer
+#COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+#RUN chmod +x /usr/local/bin/composer
 
 # Install Akeneo PIM Assets
-RUN \
+#RUN \
     #
     # Get PIM CE edition
-    #
-    wget https://github.com/akeneo/pim-community-dev/archive/master.zip -P /home/akeneo/pim-docs/ && \
-    unzip /home/akeneo/pim-docs/master.zip -d /home/akeneo/pim-docs/ && \
-    cd /home/akeneo/pim-docs/pim-community-dev-master/ && \
+    # \
+    #mkdir -p  /home/akeneo/pim-docs  && \
+    #wget https://github.com/akeneo/pim-community-dev/archive/refs/tags/master.zip -P /home/akeneo/pim-docs/ && \
+    #unzip /home/akeneo/pim-docs/master.zip -d /home/akeneo/pim-docs/ && \
+    #cd /home/akeneo/pim-docs/pim-community-dev-5.0.60/ && \
     #
     # Install dependencies
     #
-    php -d memory_limit=3G /usr/local/bin/composer install --no-suggest --ignore-platform-reqs && \
-    cd /home/akeneo/pim-docs/pim-community-dev-master/ && php bin/console pim:installer:assets --env=prod && \
-    mkdir /home/akeneo/pim-docs/pim-community-dev-master/public/css && \
-    wget http://demo.akeneo.com/css/pim.css -P /home/akeneo/pim-docs/pim-community-dev-master/public/css && \
+    #php -d memory_limit=3G /usr/local/bin/composer install --no-suggest --ignore-platform-reqs && \
+    #cd /home/akeneo/pim-docs/pim-community-dev-master/ && php bin/console pim:installer:assets --env=prod && \
+    #mkdir /home/akeneo/pim-docs/pim-community-dev-master/public/css && \
+    #wget http://demo.akeneo.com/css/pim.css -P /home/akeneo/pim-docs/pim-community-dev-master/public/css && \
     #
     # Cleanup
     #
-    rm -rf /root/.composer/cache && \
-    cd /home/akeneo/pim-docs/pim-community-dev-master/ && ls | grep -v "vendor\|public" | xargs rm -rf
+    #rm -rf /root/.composer/cache && \
+    #cd /home/akeneo/pim-docs/pim-community-dev-master/ && ls | grep -v "vendor\|public" | xargs rm -rf

--- a/Makefile
+++ b/Makefile
@@ -15,28 +15,15 @@ build: lint
 	#  -T   Displays the full stack trace if an unhandled exception occurs.
 	#  -b   Linkcheck builder checks for broken links.
 	$(DOCKER_RUN) $(DOCKER_IMAGE) sphinx-build -nWT -b html /home/akeneo/pim-docs/data /home/akeneo/pim-docs/data/pim-docs-build
-	$(DOCKER_RUN) $(DOCKER_IMAGE) cp -L -r /home/akeneo/pim-docs/pim-community-dev/public /home/akeneo/pim-docs/data/pim-docs-build/
 	@echo "\nYou are now ready to check the documentation locally in the directory \"pim-docs-build/\" and to deploy it with \"DEPLOY_HOSTNAME=foo.com DEPLOY_PORT=1985 VERSION=bar make deploy\"."
 
 deploy: build update-versions
 	$(DOCKER_RUN) -v /etc/passwd:/etc/passwd:ro -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE) rsync -e "ssh -q -p $${DEPLOY_PORT} -o StrictHostKeyChecking=no" -qarz --delete /home/akeneo/pim-docs/data/pim-docs-build/ akeneo@$${DEPLOY_HOSTNAME}:/var/www/${VERSION}
 
-lint: dependencies
+lint: docker-build
 	rm -rf pim-docs-build && mkdir pim-docs-build
 	rm -rf pim-docs-lint && mkdir pim-docs-lint
 	$(DOCKER_RUN) -v $(PWD):/home/akeneo/pim-docs/data $(DOCKER_IMAGE) sphinx-build -nWT -b linkcheck /home/akeneo/pim-docs/data /home/akeneo/pim-docs/data/pim-docs-lint
-
-dependencies: docker-build
-	mkdir -p _build
-	$(DOCKER_RUN) -v $(PWD)/_build:/home/akeneo/ce $(DOCKER_IMAGE) wget https://github.com/akeneo/pim-community-dev/archive/5.0.zip -P /home/akeneo/ce/
-	$(DOCKER_BUILD) $(DOCKER_IMAGE) unzip /home/akeneo/ce/5.0.zip -d /home/akeneo/ce/
-	$(DOCKER_BUILD) cd /home/akeneo/ce/pim-community-dev-5.0/
-	$(DOCKER_BUILD) php -d memory_limit=3G /usr/local/bin/composer install --no-suggest --ignore-platform-reqs
-	#$(DOCKER_RUN)  cd /home/akeneo/pim-docs/pim-community-dev-master/ && php bin/console pim:installer:assets --env=prod
-	#$(DOCKER_RUN) mkdir /home/akeneo/pim-docs/pim-community-dev-master/public/css
-	#$(DOCKER_RUN) wget http://demo.akeneo.com/css/pim.css -P /home/akeneo/pim-docs/pim-community-dev-master/public/css
-	#$(DOCKER_RUN)  rm -rf /root/.composer/cache
-	#$(DOCKER_RUN) cd /home/akeneo/pim-docs/pim-community-dev-master/ && ls | grep -v "vendor\|public" | xargs rm -rf
 
 docker-build:
 	docker build . --tag $(DOCKER_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ GID = $(shell id -g)
 DOCKER_IMAGE = pim-docs
 DOCKER_RUN = docker run -it --rm -u $(UID):$(GID) -v $(PWD):/home/akeneo/pim-docs/data
 DOCKER_RSYNC = $(DOCKER_RUN) -v /etc/passwd:/etc/passwd:ro -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE) rsync -e "ssh -q -p $${DEPLOY_PORT} -o StrictHostKeyChecking=no" -qarz --delete
+DOCKER_BUILD = $(DOCKER_RUN) -v $(PWD)/_build:/home/akeneo/ce
 
 .DEFAULT_GOAL := build
 .PHONY: build, deploy, docker-build, update-versions
@@ -14,16 +15,28 @@ build: lint
 	#  -T   Displays the full stack trace if an unhandled exception occurs.
 	#  -b   Linkcheck builder checks for broken links.
 	$(DOCKER_RUN) $(DOCKER_IMAGE) sphinx-build -nWT -b html /home/akeneo/pim-docs/data /home/akeneo/pim-docs/data/pim-docs-build
-	$(DOCKER_RUN) $(DOCKER_IMAGE) cp -L -r /home/akeneo/pim-docs/pim-community-dev-master/public /home/akeneo/pim-docs/data/pim-docs-build/
+	$(DOCKER_RUN) $(DOCKER_IMAGE) cp -L -r /home/akeneo/pim-docs/pim-community-dev/public /home/akeneo/pim-docs/data/pim-docs-build/
 	@echo "\nYou are now ready to check the documentation locally in the directory \"pim-docs-build/\" and to deploy it with \"DEPLOY_HOSTNAME=foo.com DEPLOY_PORT=1985 VERSION=bar make deploy\"."
 
 deploy: build update-versions
 	$(DOCKER_RUN) -v /etc/passwd:/etc/passwd:ro -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE) rsync -e "ssh -q -p $${DEPLOY_PORT} -o StrictHostKeyChecking=no" -qarz --delete /home/akeneo/pim-docs/data/pim-docs-build/ akeneo@$${DEPLOY_HOSTNAME}:/var/www/${VERSION}
 
-lint: docker-build
+lint: dependencies
 	rm -rf pim-docs-build && mkdir pim-docs-build
 	rm -rf pim-docs-lint && mkdir pim-docs-lint
 	$(DOCKER_RUN) -v $(PWD):/home/akeneo/pim-docs/data $(DOCKER_IMAGE) sphinx-build -nWT -b linkcheck /home/akeneo/pim-docs/data /home/akeneo/pim-docs/data/pim-docs-lint
+
+dependencies: docker-build
+	mkdir -p _build
+	$(DOCKER_RUN) -v $(PWD)/_build:/home/akeneo/ce $(DOCKER_IMAGE) wget https://github.com/akeneo/pim-community-dev/archive/5.0.zip -P /home/akeneo/ce/
+	$(DOCKER_BUILD) $(DOCKER_IMAGE) unzip /home/akeneo/ce/5.0.zip -d /home/akeneo/ce/
+	$(DOCKER_BUILD) cd /home/akeneo/ce/pim-community-dev-5.0/
+	$(DOCKER_BUILD) php -d memory_limit=3G /usr/local/bin/composer install --no-suggest --ignore-platform-reqs
+	#$(DOCKER_RUN)  cd /home/akeneo/pim-docs/pim-community-dev-master/ && php bin/console pim:installer:assets --env=prod
+	#$(DOCKER_RUN) mkdir /home/akeneo/pim-docs/pim-community-dev-master/public/css
+	#$(DOCKER_RUN) wget http://demo.akeneo.com/css/pim.css -P /home/akeneo/pim-docs/pim-community-dev-master/public/css
+	#$(DOCKER_RUN)  rm -rf /root/.composer/cache
+	#$(DOCKER_RUN) cd /home/akeneo/pim-docs/pim-community-dev-master/ && ls | grep -v "vendor\|public" | xargs rm -rf
 
 docker-build:
 	docker build . --tag $(DOCKER_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ GID = $(shell id -g)
 DOCKER_IMAGE = pim-docs
 DOCKER_RUN = docker run -it --rm -u $(UID):$(GID) -v $(PWD):/home/akeneo/pim-docs/data
 DOCKER_RSYNC = $(DOCKER_RUN) -v /etc/passwd:/etc/passwd:ro -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE) rsync -e "ssh -q -p $${DEPLOY_PORT} -o StrictHostKeyChecking=no" -qarz --delete
-DOCKER_BUILD = $(DOCKER_RUN) -v $(PWD)/_build:/home/akeneo/ce
 
 .DEFAULT_GOAL := build
 .PHONY: build, deploy, docker-build, update-versions

--- a/cloud_edition/flexibility_mode/docs/disk_usage.rst
+++ b/cloud_edition/flexibility_mode/docs/disk_usage.rst
@@ -101,7 +101,7 @@ This command will not remove thumbnails generated for preview, if you also want 
 
 .. code-block:: bash
 
-    php bin/console akeneo:asset-manager:thumbnail-cache:clear
+    php bin/console akeneo:asset-manager:thumbnail-cache:clear --all
 
 
 .. warning::

--- a/cloud_edition/flexibility_mode/docs/environments_access.rst
+++ b/cloud_edition/flexibility_mode/docs/environments_access.rst
@@ -98,6 +98,7 @@ If **akeneo**, as an SSH user or as a PIM process, creates files in the SFTP sub
     $ chmod u=rwX,g=rwXs,o= /data/transfert/pim/*
 
 .. _`Filezilla`: https://filezilla-project.org
+.. _`helpdesk`: https://helpdesk.akeneo.com
 .. _`specific tasks`: ./partners.html
 .. _`GitHub Help Center`:  https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent
 .. _`Akeneo Help Center`:  https://help.akeneo.com/portal/articles/access-akeneo-flexibility.html?utm_source=akeneo-docs&utm_campaign=flexibility_partner_starterkit

--- a/cloud_edition/flexibility_mode/docs/environments_access.rst
+++ b/cloud_edition/flexibility_mode/docs/environments_access.rst
@@ -98,7 +98,6 @@ If **akeneo**, as an SSH user or as a PIM process, creates files in the SFTP sub
     $ chmod u=rwX,g=rwXs,o= /data/transfert/pim/*
 
 .. _`Filezilla`: https://filezilla-project.org
-.. _`helpdesk`: https://helpdesk.akeneo.com
 .. _`specific tasks`: ./partners.html
 .. _`GitHub Help Center`:  https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent
 .. _`Akeneo Help Center`:  https://help.akeneo.com/portal/articles/access-akeneo-flexibility.html?utm_source=akeneo-docs&utm_campaign=flexibility_partner_starterkit

--- a/maintain_pim/first_aid_kit/index.rst
+++ b/maintain_pim/first_aid_kit/index.rst
@@ -95,6 +95,9 @@ Clear the PIM cache (also known as "Symfony cache") by running the following com
     cd /path/to/your/pim/
     php bin/console cache:clear --env=prod --no-warmup
 
+ 
+You could use the command `partners_clear_cache` if you are on a Akeneo Cloud Offer. You can find more commands in our `_System Administration & Services Management page <https://docs.akeneo.com/4.0/cloud_edition/flexibility_mode/docs/system_administration.html>`__.
+
 Step 9: did you consider the volume of your catalog?
 ----------------------------------------------------
 

--- a/technical_architecture/localization/how_to_use_the_localizers.rst
+++ b/technical_architecture/localization/how_to_use_the_localizers.rst
@@ -63,5 +63,4 @@ If you want to add your own format, you have to configure it in your `app/config
                 - { value: 'dd/MM/yyyy', label: 'dd/mm/yyyy' }
                 - { value: 'dd.MM.yyyy', label: 'dd.mm.yyyy' }
 
-
-The key "value" has to contain characters defined in https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1SimpleDateFormat.html#details .
+The key "value" has to contain characters defined in https://unicode-org.github.io/icu/userguide/format_parse/datetime/ .


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

During pull-up 4.0 => 5.0 we saw that build was broken due to php 8 upgrade.
It was first decided to refactor Dockerfile to move "CE dependency build" to Makefile, and use akeneo/pim-php-dev:5.0 as base image to simplify build.
But during testing, i realized that the built files were not used on the website using "wget mirror".
See https://akeneo.atlassian.net/browse/PIM-10185
for detailed analysis.
Analysis shows other unreferenced files that should be cleaned up in another pr.
<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
