### PR TITLE
PIM-10202: Fix the limit of options in a reference entity attribute

### DIFF
--- a/reference_entities/configure_entity_limits.rst
+++ b/reference_entities/configure_entity_limits.rst
@@ -35,15 +35,8 @@ If you want to create more, you have to edit the ``reference_entity_maximum_attr
 
 Raise the limit of Options for "Simple Option" and "Multiple Option" Attributes
 -------------------------------------------------------------------------------
-By default, you can't create more than **100** options for each **"Simple Option" and "Multiple Option"**.
-If you want to create more, you have to edit the ``reference_entity_option_limit_per_list_attribute`` parameter, for example:
-
-.. code-block:: yaml
-    :linenos:
-
-    # app/config/parameters.yml
-    parameters:
-        reference_entity_option_limit_per_list_attribute: 200
+You can't create more than **100** options for each **"Simple Option" and "Multiple Option"**.
+If you need more than 100 options, we advise you to create a dedicated reference entity.
 
 
 Raise the limit of Records per Reference Entity


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

The limit of options is hardcoded. The team decided to fix the documentation

https://akeneo.atlassian.net/browse/PIM-10202


**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
