### PR TITLE
CPM-152: add migration command for job queue

### DIFF
--- a/migrate_pim/upgrade/upgrade_from_50_to_60.rst
+++ b/migrate_pim/upgrade/upgrade_from_50_to_60.rst
@@ -175,11 +175,13 @@ Migrate the job queue
 In 6.0 we set up a new job queue. You may have jobs awaiting in the old queue, they must be migrated in the new queue:
 
 .. code:: bash
+
     $ bin/console akeneo:batch:migrate-job-messages-from-old-queue
 
 If you want to skip the interactive question and want to migrate directly:
 
 .. code:: bash
+
     $ bin/console akeneo:batch:migrate-job-messages-from-old-queue --no-interaction
 
 Migrating your custom code

--- a/migrate_pim/upgrade/upgrade_from_50_to_60.rst
+++ b/migrate_pim/upgrade/upgrade_from_50_to_60.rst
@@ -169,6 +169,18 @@ Migrate your data
 
     The message "The migration has already been performed." concerning the "data-quality-insights" migration could be ignored .
 
+Migrate the job queue
+*********************
+
+In 6.0 we set up a new job queue. You may have jobs awaiting in the old queue, they must be migrated in the new queue:
+
+.. code:: bash
+    $ bin/console akeneo:batch:migrate-job-messages-from-old-queue
+
+If you want to skip the interactive question and want to migrate directly:
+
+.. code:: bash
+    $ bin/console akeneo:batch:migrate-job-messages-from-old-queue --no-interaction
 
 Migrating your custom code
 **************************


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

In 5.0 the job queue was a custom queue in the database. In 6.0 the queue is handled by Symfony Messenger that can work with several adapters (database, pub/sub, ....).  
The awaiting messages need to be migrated in the new queue.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
