### PR TITLE
BH-1113: Update migration doc for v6 - Add all migrations before stac…

### DIFF
--- a/migrate_pim/upgrade/upgrade_from_50_to_60.rst
+++ b/migrate_pim/upgrade/upgrade_from_50_to_60.rst
@@ -9,6 +9,22 @@ Disclaimer
 Make sure your production database is backed-up before performing the data migration.
 The queue daemon(s) must be stopped as well.
 
+Prepare your project for the new technical stack
+************************************************
+
+Your current v5.0 application must have up to date migrations before migrating on the new technical stack.
+
+The root of your current installation dir is referred as $INSTALLATION_DIR.
+
+.. code:: bash
+
+    $ export APP_ENV=prod
+    $ cd $INSTALLATION_DIR
+    $ cp -R ./vendor/akeneo/pim-community-dev/upgrades/* ./upgrades/
+    $ cp -R ./vendor/akeneo/pim-enterprise-dev/upgrades/* ./upgrades/
+    $ php bin/console doctrine:migrations:version --add --all -q
+    $ rm -rf var/cache/
+
 Requirements
 ************
 
@@ -53,16 +69,6 @@ Prepare your project
 Akeneo PIM composer.json
 ----------------------------
 The root of your current installation dir is referred as $INSTALLATION_DIR.
-
-
-.. code:: bash
-
-    $ export APP_ENV=prod
-    $ cd $INSTALLATION_DIR
-    $ cp -R ./vendor/akeneo/pim-community-dev/upgrades/* ./upgrades/
-    $ cp -R ./vendor/akeneo/pim-enterprise-dev/upgrades/* ./upgrades/
-    $ php bin/console doctrine:migrations:version --add --all -q
-    $ rm -rf var/cache/
 
 Community Edition
 ^^^^^^^^^^^^^^^^^

--- a/migrate_pim/upgrade_major_version.rst
+++ b/migrate_pim/upgrade_major_version.rst
@@ -7,11 +7,9 @@ These new major versions bring new features and larger changes to answer clients
 Upgrade from 1.7 to 2.0
 -----------------------
 
-To migrate from 1.7 to 2.0, we recommend the use of our brand new migration tool `Transporteo`_.
+To migrate from 1.7 to 2.0, we recommend the use of our migration tool `Transporteo`_.
 
 .. _Transporteo: https://github.com/akeneo/transporteo
-
-We're continuously improving Transporteo to cover more and more use cases and automate more and more the migrations.
 
 Upgrade from 2.3 to 3.1
 -----------------------


### PR DESCRIPTION
We can run `bin/console` with _v5 codebase and PHP7.4_
We can run `bin/console` with _v6 codebase and PHP8.0_

But we cannot run `bin/console` with _v5 codebase on PHP8.0 stack_

We must update all v5 migrations before going on the new PHP8.0 v6 stack