### PR TITLE
PIM:10344: Add dqi command to launch in 5.0 to 6.0 migration

### DIFF
--- a/migrate_pim/upgrade/upgrade_from_50_to_60.rst
+++ b/migrate_pim/upgrade/upgrade_from_50_to_60.rst
@@ -157,7 +157,7 @@ Migrate your data
 
     $ bin/console doctrine:migrations:migrate
     $ bin/console pimee:data-quality-insights:migrate-product-criterion-evaluation
-    $ bin/console akeneo:batch:publish-job-to-queue data_quality_insights_recompute_products_scores
+    $ bin/console pim:data-quality-insights:recompute-product-scores
 
 .. note::
 

--- a/migrate_pim/upgrade/upgrade_from_50_to_60.rst
+++ b/migrate_pim/upgrade/upgrade_from_50_to_60.rst
@@ -157,6 +157,7 @@ Migrate your data
 
     $ bin/console doctrine:migrations:migrate
     $ bin/console pimee:data-quality-insights:migrate-product-criterion-evaluation
+    $ bin/console akeneo:batch:publish-job-to-queue data_quality_insights_recompute_products_scores
 
 .. note::
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

Add DQI command in 5.0 to 6.0 migration, paragraph "Migrate your data"

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
