### PR TITLE
Remove Composer cache mount

### DIFF
--- a/install_pim/docker/installation_docker.rst
+++ b/install_pim/docker/installation_docker.rst
@@ -54,7 +54,7 @@ The following command will create a PIM project in the current directory. Please
     $ cd pim
     $ docker run -ti -u www-data --rm \
         -e COMPOSER_MEMORY_LIMIT=4G \
-        -v $(pwd):/srv/pim -v ~/.composer:/var/www/.composer -w /srv/pim \
+        -v $(pwd):/srv/pim -w /srv/pim \
         akeneo/pim-php-dev:6.0 php /usr/local/bin/composer create-project \
         akeneo/pim-community-standard /srv/pim "6.0.*@stable"
 


### PR DESCRIPTION
Mounting cache volumes should be the responsability of the dev user

The cache dir on the dev machine can be pretty anywhere, or nowhere if there is no local composer