### PR TITLE
Mount /etc/password for every Docker command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 UID = $(shell id -u)
 GID = $(shell id -g)
 DOCKER_IMAGE = pim-docs
-DOCKER_RUN = docker run -it --rm -u $(UID):$(GID) -v $(PWD):/home/akeneo/pim-docs/data
-DOCKER_RSYNC = $(DOCKER_RUN) -v /etc/passwd:/etc/passwd:ro -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE) rsync -e "ssh -q -p $${DEPLOY_PORT} -o StrictHostKeyChecking=no" -qarz --delete
+DOCKER_RUN = docker run -it --rm -u $(UID):$(GID) -v /etc/passwd:/etc/passwd:ro -v $(PWD):/home/akeneo/pim-docs/data
+DOCKER_RSYNC = $(DOCKER_RUN) -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE) rsync -e "ssh -q -p $${DEPLOY_PORT} -o StrictHostKeyChecking=no" -qarz --delete
 
 .DEFAULT_GOAL := build
 .PHONY: build, deploy, docker-build, update-versions
@@ -17,7 +17,7 @@ build: lint
 	@echo "\nYou are now ready to check the documentation locally in the directory \"pim-docs-build/\" and to deploy it with \"DEPLOY_HOSTNAME=foo.com DEPLOY_PORT=1985 VERSION=bar make deploy\"."
 
 deploy: build update-versions
-	$(DOCKER_RUN) -v /etc/passwd:/etc/passwd:ro -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE) rsync -e "ssh -q -p $${DEPLOY_PORT} -o StrictHostKeyChecking=no" -qarz --delete /home/akeneo/pim-docs/data/pim-docs-build/ akeneo@$${DEPLOY_HOSTNAME}:/var/www/${VERSION}
+	$(DOCKER_RUN) -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE) rsync -e "ssh -q -p $${DEPLOY_PORT} -o StrictHostKeyChecking=no" -qarz --delete /home/akeneo/pim-docs/data/pim-docs-build/ akeneo@$${DEPLOY_HOSTNAME}:/var/www/${VERSION}
 
 lint: docker-build
 	rm -rf pim-docs-build && mkdir pim-docs-build


### PR DESCRIPTION
In case the running user (aka the dev) running `make build` is not the 1000:1000 user, we will have file permissions issues when running make build. We can avoid this by mounting the dev `/etc/password` into the container to map the correct UIDs.

It was indeed done in other commands of this Makefile and I just moved it to the base command to always use it.