### PR TITLE
Flexibility: rm notes about manage several daemons at once

### DIFF
--- a/cloud_edition/flexibility_mode/docs/job_consumers_and_workers.rst
+++ b/cloud_edition/flexibility_mode/docs/job_consumers_and_workers.rst
@@ -97,17 +97,6 @@ Examples
       # Disable the consumer not to be started automatically at instance boot up
       partners_systemctl pim_webhook_consumer disable
 
-- Manage all daemons at once:
-   .. code-block:: bash
-      :linenos:
-
-      # Check the status of all daemons
-      partners_systemctl pim_job_consumer@* status
-
-      # Restart all daemons
-      partners_systemctl pim_job_consumer@* restart
-
-
 Onboarder
 ---------
 


### PR DESCRIPTION
**Description**

In Flexibility (Paas) instances, the wrapper **partners_systemctl** will be update https://github.com/akeneo/cloud-paas/pull/1256 to avoid errors raised by the command:

`$ partners_systemctl pim_job_consumer@* enable`

From now, customer won't be able to manage several daemons at once with the wrapper.
This PR removes the notes about that in this doc.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
