### PR TITLE
Fix migrations command for major version upgrade

### DIFF
--- a/migrate_pim/upgrade/upgrade_from_40_to_50.rst
+++ b/migrate_pim/upgrade/upgrade_from_40_to_50.rst
@@ -72,7 +72,7 @@ The root of your current installation dir is referred as $INSTALLATION_DIR.
     $ cd $INSTALLATION_DIR
     $ cp -R ./vendor/akeneo/pim-community-dev/upgrades/* ./upgrades/
     $ cp -R ./vendor/akeneo/pim-enterprise-dev/upgrades/* ./upgrades/
-    $ php bin/console doctrine:migrations:version --add --all -q
+    $ php bin/console doctrine:migrations:migrate
     $ rm -rf var/cache/
 
 Community Edition

--- a/migrate_pim/upgrade/upgrade_from_50_to_60.rst
+++ b/migrate_pim/upgrade/upgrade_from_50_to_60.rst
@@ -22,12 +22,12 @@ The root of your current installation dir is referred as $INSTALLATION_DIR.
     $ cd $INSTALLATION_DIR
     $ cp -R ./vendor/akeneo/pim-community-dev/upgrades/* ./upgrades/
     $ cp -R ./vendor/akeneo/pim-enterprise-dev/upgrades/* ./upgrades/
-    $ php bin/console doctrine:migrations:version --add --all -q
+    $ php bin/console doctrine:migrations:migrate
     $ rm -rf var/cache/
 
 .. note::
 
-    WARNING: please note that this part of the migration needs to be executed on your PIM v5.0 ``before`` upgrading your technical stack. 
+    WARNING: please note that this part of the migration needs to be executed on your PIM v5.0 ``before`` upgrading your technical stack.
 
 
 Requirements


### PR DESCRIPTION
When doing a major version upgrade, the current PIM installation must be up to date with all migrations. That means *PLAYING* them all, and not just adding them as done in the Doctrine migration system.