### PR TITLE
Set directory in supervisor queue daemon example

### DIFF
--- a/install_pim/manual/daemon_queue.rst
+++ b/install_pim/manual/daemon_queue.rst
@@ -100,7 +100,8 @@ Create a file in the configuration directory of supervisor ``/etc/supervisor/con
     :linenos:
 
     [program:akeneo_queue_daemon]
-    command=/path/to/php /path/to/your/pim/bin/console messenger:consume ui_job import_export_job data_maintenance_job --env=prod -vv
+    directory=/path/to/your/pim
+    command=/path/to/php bin/console messenger:consume ui_job import_export_job data_maintenance_job --env=prod -vv
     autostart=false
     autorestart=true
     stderr_logfile=/var/log/akeneo_daemon.err.log


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

The queue daemon should be ran from the right directory

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
