### PR TITLE
Pullup 6.0 does not target 7.0 it target master directly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,8 @@ workflows:
         jobs:
             - pull-up/pull-up:
                   from: "6.0"
-                  into: "master"
-                  branch_prefix: "60_to_master"
+                  into: "7.0"
+                  branch_prefix: "60_to_70"
                   github_token: MICHEL_TAG_TOKEN
                   github_username: "micheltag"
                   slack_webhook: "${SLACK_URL_PULL_UP}"

--- a/conf.py
+++ b/conf.py
@@ -282,4 +282,4 @@ texinfo_documents = [
 linkcheck_anchors = False
 linkcheck_ignore = [r'http://localhost:\d+/', r'http://your\.akeneo-pim\.url.*']
 
-user_agent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99'
+user_agent = 'curl'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
