### PR TITLE
Update system_install_ubuntu_2204.rst

### DIFF
--- a/install_pim/manual/system_requirements/system_install_ubuntu_2204.rst
+++ b/install_pim/manual/system_requirements/system_install_ubuntu_2204.rst
@@ -55,7 +55,7 @@ Then, install PHP and the required extensions:
 
 .. code-block:: bash
 
-    $ apt-get install php8.1-cli php8.1-apcu php8.1-bcmath php8.1-curl php8.1-opcache php8.1-fpm php8.1-gd php8.1-intl php8.1-mysql php8.1-xml php8.1-zip php8.1-mbstring php8.1-imagick
+    $ apt-get install php8.1-cli php8.1-apcu php8.1-bcmath php8.1-curl php8.1-opcache php8.1-fpm php8.1-gd php8.1-intl php8.1-mysql php8.1-xml php8.1-zip php8.1-mbstring php8.1-imagick php8.1-grpc
 
 Composer v2
 ***********


### PR DESCRIPTION
PHP 8.1 is missing required extension ext-grpc, so I added: php8.1-grpc

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
