### PR TITLE
[SQUIR-159] enable webhook consumer docs

### DIFF
--- a/cloud_edition/flexibility_mode/docs/job_consumers_and_workers.rst
+++ b/cloud_edition/flexibility_mode/docs/job_consumers_and_workers.rst
@@ -74,6 +74,19 @@ Examples
       # Enable the consumer to be started automatically at instance boot up
       partners_systemctl pim_job_consumer@4 enable
 
+- Enable the default PIM webhook consumer (which is required for the `Events API <https://api.akeneo.com/events-reference/events-reference-6.0/products.html>`_):
+   .. code-block:: bash
+      :linenos:
+
+      # Start the consumer
+      partners_systemctl pim_webhook_consumer start
+
+      # Enable the consumer to be started automatically when the instance restarts
+      partners_systemctl pim_webhook_consumer enable
+
+      # Check the status to ensure the consumer is running and enabled
+      partners_systemctl pim_webhook_consumer status
+
 - Remove an existing daemon (not possible on Akeneo default ones):
    .. code-block:: bash
       :linenos:


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (Please note that every external contribution must be done on the default branch (4.0 in April 2020) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-docs/blob/master/.github/CONTRIBUTING.md) --->

**Description**

Updates 6.0 documentation to explicitly show how to enable the webhook consumer, since its syntax is slightly different from normal job consumers.

This also adds a note that explains that the webhook consumer is required to be running for the Events API to work.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
