### PR TITLE
docs: fix typos

### DIFF
--- a/cloud_edition/flexibility_mode/docs/environments_access.rst
+++ b/cloud_edition/flexibility_mode/docs/environments_access.rst
@@ -65,7 +65,7 @@ Error: Connection refused
 Something prevents the connection from being established, it can mean that:
 
 - you have a firewall that blocks the port 22 or SSH protocol. Contact your administrator to check for such restrictions.
-- your IP adress is not allowed to connect. IP access ranges have to be explicitely allowed through the Portal.
+- your IP address is not allowed to connect. IP access ranges have to be explicitly allowed through the Portal.
 - if none of the above apply, please contact us.
 
 SSH File Transfer Protocol (SFTP)
@@ -120,7 +120,7 @@ Copy data from one instance to another
 
 **Prerequisites:**
 
-- Get SSH key access to both intances for akeneo user.
+- Get SSH key access to both instances for akeneo user.
 - Get network access to instances.
 
 **Usage:**

--- a/contribute_to_pim/front.rst
+++ b/contribute_to_pim/front.rst
@@ -149,7 +149,7 @@ This first command will build the javascript file for production. The javascript
 yarn webpack-dev
 ++++++++++++++++
 
-This command will build the javascript artefacts in development mode. The size of the generated bundle will be higher and quicker to generate. It's the prefered way to rebuild the frontend after checking out another branch when you are not actively working on the frontend.
+This command will build the javascript artefacts in development mode. The size of the generated bundle will be higher and quicker to generate. It's the preferred way to rebuild the frontend after checking out another branch when you are not actively working on the frontend.
 
 yarn webpack-watch
 ++++++++++++++++++

--- a/manipulate_pim_data/connect/configure_event_subscription_network.rst
+++ b/manipulate_pim_data/connect/configure_event_subscription_network.rst
@@ -12,7 +12,7 @@ The following domains are always blacklisted:
 - `object-storage`
 - `mysql`
 
-Additionnaly, we also block the ranges of IPs defined in the RFC1918.
+Additionally, we also block the ranges of IPs defined in the RFC1918.
 
 However, **you may need to add an exception to those IP address ranges**, this chapter explains how.
 


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

2 typos in `cloud_edition/flexibility_mode/docs/environments_access.rst`
1 typo in `contribute_to_pim/front.rst`
1 typo in `manipulate_pim_data/connect/configure_event_subscription_network.rst`


Best!