### PR TITLE
SQUIR-236-7.0-rmv-demo remove link to demo.akeneo.com

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -282,8 +282,7 @@ texinfo_documents = [
 linkcheck_anchors = False
 linkcheck_ignore = [
     r'http://localhost:\d+/',
-    r'http://your\.akeneo-pim\.url.*',
-    r'http://demo.akeneo.com/user/login' # Temporary added because demo.akeneo.com is down
+    r'http://your\.akeneo-pim\.url.*'
     ]
 
 user_agent = 'curl'

--- a/contribute_to_pim/report_bug.rst.inc
+++ b/contribute_to_pim/report_bug.rst.inc
@@ -11,7 +11,6 @@ Report a Bug
 
 **Community Edition**
 
-* Check if the issue is reproducible on `Demo website <http://demo.akeneo.com/user/login>`_
 * Check if this issue is `already known <https://github.com/akeneo/pim-community-dev/issues>`_
 * Clone `the development repository <https://github.com/akeneo/pim-community-dev>`_ and checkout the branch of the version you want to test
 * Reproduce the bug


### PR DESCRIPTION
Removed link to demo.akeneo.com as not valid anymore in conf.py and /contribute_to_pim/report_bug.rst.inc