### PR TITLE
Update docker image for CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,21 +2,21 @@ version: 2.1
 jobs:
     build:
         machine:
-            image: ubuntu-2204:2022.07.1
+            image: ubuntu-2204:current
         steps:
             - checkout
             - run: make build
 
     check-external-link:
         machine:
-            image: ubuntu-2204:2022.07.1
+            image: ubuntu-2204:current
         steps:
             - checkout
             - run: make lint
 
     deploy_staging:
         machine:
-            image: ubuntu-2204:2022.07.1
+            image: ubuntu-2204:current
         steps:
             - checkout
             - add_ssh_keys
@@ -26,7 +26,7 @@ jobs:
 
     deploy_production:
         machine:
-            image: ubuntu-2204:2022.07.1
+            image: ubuntu-2204:current
         steps:
             - checkout
             - add_ssh_keys


### PR DESCRIPTION
**Description**

Current image used is deprecated. 

`ubuntu-2204:2022.07.1` => `ubuntu-2204:current`