### PR TITLE
Update inspect database commands

### DIFF
--- a/migrate_pim/migrate_to_saas.rst
+++ b/migrate_pim/migrate_to_saas.rst
@@ -177,9 +177,8 @@ Please send us the results of the following shell commands so that we can ensure
 .. code:: bash
 
     $ cd /home/akeneo/pim
-    $ bin/console pimee:database:inspect -f --env=dev
-    $ composer require jfcherng/php-diff
-    $ bin/console pimee:database:diff --env=dev
+    $ bin/console pimee:database:inspect -f --env=prod
+    $ bin/console pimee:database:diff --env=prod
     $
     $ bin/console doctrine:migrations:status
     $


### PR DESCRIPTION
**Description**

update the commands `pimee:database:diff` and `pimee:database:inspect` with `--env=prod`
these commands depends on the library `jfcherng/php-diff` which was required in dev environment only in PIM v6, but the library now included in prod in PIM v7 and there is no need to install it or run the commands in `--env=dev` 

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Technical Review and 2 GTM        | Todo
| English Review and 1 GTM          | Todo


`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
